### PR TITLE
Avoid publishing /clock twice per cycle

### DIFF
--- a/mujoco_ros/src/mujoco_sim.cpp
+++ b/mujoco_ros/src/mujoco_sim.cpp
@@ -165,13 +165,13 @@ void setupVFS(const std::string &filename, const std::string &content /* = std::
 
 void init(std::string modelfile)
 {
-	// If not already set, set use_sim_time param manually
-	// This needs to happen before the NodeHandle creation
+	// use_sim_time should be set in roslaunch before running any node.
+	// Otherwise nodes might behave unintendedly. Hence, issue an error in this case.
 	bool use_sim_time_set;
-	ros::param::get("/use_sim_time", use_sim_time_set);
-	if (!use_sim_time_set) {
-		ROS_INFO_NAMED("mujoco", "use_sim_time was not set. Setting it manually");
-		ros::param::set("/use_sim_time", true);
+	if (!ros::param::get("/use_sim_time", use_sim_time_set) || !use_sim_time_set) {
+		ROS_FATAL_NAMED("mujoco", "/use_sim_time ROS param is not true. Make sure it is set before starting any node, "
+		                          "otherwise nodes might behave unexpectedly.");
+		return;
 	}
 
 	nh_.reset(new ros::NodeHandle("~"));

--- a/mujoco_ros/src/mujoco_sim.cpp
+++ b/mujoco_ros/src/mujoco_sim.cpp
@@ -452,10 +452,6 @@ void simulate(void)
 		model = main_env_->model;
 		data  = main_env_->data;
 
-		if (data) {
-			publishSimTime(data->time);
-		}
-
 		if (settings_.run && settings_.busywait) {
 			std::this_thread::yield();
 		} else {


### PR DESCRIPTION
Was there a specific reason to publish the time at the beginning of this function already?