### PR TITLE
Fix controller reset

### DIFF
--- a/mujoco_ros/README.md
+++ b/mujoco_ros/README.md
@@ -55,6 +55,9 @@ where `PATH/TO/MUJOCO/DIR` is `~/.mujoco/mujoco222` if you used the recommended 
 4. Build with `catkin_build` or `catkin b`.
 5. Source your workspace and try `roslaunch mujoco_ros demo.launch` to test if it runs.
 
+> **Warning**
+> To prevent action servers ignoring actions for a limited time after resetting the simulation, until https://github.com/ros/actionlib/pull/203 is merged, you need to build the PR branch and any packages implementing action servers (like MoveIt) yourself. Additionally, for the Franka Emika Panda robot, until https://github.com/frankaemika/franka_ros/pull/292 is merged, you need to build the PR branch yourself, otherwise controlling the robot after time resets is buggy.
+
 # Licensing
 
 This work is licensed under the BSD 3-Clause License (see LICENSE).

--- a/mujoco_ros/include/mujoco_ros/mujoco_sim.h
+++ b/mujoco_ros/include/mujoco_ros/mujoco_sim.h
@@ -181,6 +181,7 @@ static double last_rendered_ = 0;
 // ROS callback for sim time publisher on /clock
 void publishSimTime(mjtNum time);
 static ros::Publisher pub_clock_;
+static bool use_sim_time_;
 static boost::shared_ptr<ros::NodeHandle> nh_;
 
 // ROS TF2

--- a/mujoco_ros/include/mujoco_ros/mujoco_sim.h
+++ b/mujoco_ros/include/mujoco_ros/mujoco_sim.h
@@ -307,6 +307,7 @@ struct
 	int run              = 0;
 	int key              = 0;
 	int loadrequest      = 0;
+	int resetrequest     = 0;
 	int slow_down        = 1;
 	bool speed_changed   = true;
 	double ctrlnoisestd  = 0.0;

--- a/mujoco_ros/include/mujoco_ros/mujoco_sim.h
+++ b/mujoco_ros/include/mujoco_ros/mujoco_sim.h
@@ -192,9 +192,6 @@ static std::vector<ros::ServiceServer> service_servers_;
 // Actions
 static std::unique_ptr<actionlib::SimpleActionServer<mujoco_ros_msgs::StepAction>> action_step_;
 
-// Keep track of time for resets to not mess up ros time
-static mjtNum last_time_ = -1;
-
 // constants
 const int maxgeom_          = 5000; // preallocated geom array in mjvScene
 const double syncmisalign_  = 0.1; // maximum time mis-alignment before re-sync

--- a/mujoco_ros/src/mujoco_sim.cpp
+++ b/mujoco_ros/src/mujoco_sim.cpp
@@ -342,9 +342,9 @@ void requestExternalShutdown(void)
 void resetSim()
 {
 	if (main_env_->model) {
-		// sim_mtx is already locked and we wait a little to ensure no old tf messages are being sent after the reset
-		ROS_DEBUG_NAMED("mujoco", "Sleeping to give tf message transport enough time");
-		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+		// sim_mtx is already locked
+		ROS_DEBUG_NAMED("mujoco", "Sleeping to ensure all (old) ROS messages are sent");
+		std::this_thread::sleep_for(std::chrono::milliseconds(100));
 		ROS_DEBUG_NAMED("mujoco", "Starting reset");
 
 		mj_resetData(main_env_->model.get(), main_env_->data.get());

--- a/mujoco_ros/src/mujoco_sim.cpp
+++ b/mujoco_ros/src/mujoco_sim.cpp
@@ -344,8 +344,6 @@ void resetSim()
 {
 	if (main_env_->model) {
 		mj_resetData(main_env_->model.get(), main_env_->data.get());
-		if (last_time_ > 0)
-			main_env_->data->time = last_time_;
 		loadInitialJointStates(main_env_->model, main_env_->data);
 		main_env_->reset();
 		mj_forward(main_env_->model.get(), main_env_->data.get());

--- a/mujoco_ros/src/mujoco_sim.cpp
+++ b/mujoco_ros/src/mujoco_sim.cpp
@@ -195,13 +195,7 @@ void init(std::string modelfile)
 		sim_mode_ = simMode::SINGLE;
 	}
 
-	pub_clock_  = nh_->advertise<rosgraph_msgs::Clock>("/clock", 1);
-	double time = ros::Time::now().toSec();
-	if (time > 0) {
-		ROS_DEBUG_STREAM_NAMED("mujoco", "ROS time was not 0, starting with time at " << time << " seconds");
-		last_time_ = (mjtNum)time;
-	}
-	publishSimTime(time);
+	pub_clock_ = nh_->advertise<rosgraph_msgs::Clock>("/clock", 1);
 
 	nh_->param<bool>("benchmark_time", benchmark_env_time_, false);
 

--- a/mujoco_ros/src/mujoco_sim.cpp
+++ b/mujoco_ros/src/mujoco_sim.cpp
@@ -351,6 +351,7 @@ void resetSim()
 		sensorUpdate(main_env_->model, main_env_->data);
 		updateSettings(main_env_->model);
 	}
+	settings_.resetrequest = 0;
 }
 
 void synchedMultiSimStep()
@@ -413,6 +414,10 @@ void eventloop(void)
 				loadModel();
 			} else if (settings_.loadrequest > 1) {
 				settings_.loadrequest = 1;
+			}
+
+			if (settings_.resetrequest == 1) {
+				resetSim();
 			}
 
 			if (vis_) {
@@ -1139,7 +1144,7 @@ void uiEvent(mjuiState *state)
 		else if (it && it->sectionid == SECT_SIMULATION) {
 			switch (it->itemid) {
 				case 1: // reset
-					resetSim();
+					settings_.resetrequest = 1;
 					break;
 
 				case 2: // Reload
@@ -2323,7 +2328,7 @@ bool setPauseCB(mujoco_ros_msgs::SetPause::Request &req, mujoco_ros_msgs::SetPau
 
 bool resetCB(std_srvs::Empty::Request &req, std_srvs::Empty::Response &resp)
 {
-	resetSim();
+	settings_.resetrequest = 1;
 	return true;
 }
 

--- a/mujoco_ros/src/mujoco_sim.cpp
+++ b/mujoco_ros/src/mujoco_sim.cpp
@@ -400,7 +400,6 @@ void publishSimTime(mjtNum time)
 	rosgraph_msgs::Clock ros_time;
 	ros_time.clock.fromSec(time);
 	pub_clock_.publish(ros_time);
-	last_time_ = time;
 }
 
 void eventloop(void)
@@ -792,10 +791,6 @@ void loadModel(void)
 
 void setupEnv(MujocoEnvPtr env)
 {
-	// if time == 0, then sim is loaded for the first time
-	if (last_time_ > 0)
-		env->data->time = last_time_;
-
 	loadInitialJointStates(env->model, env->data);
 
 	mj_forward(env->model.get(), env->data.get());

--- a/mujoco_ros/src/mujoco_sim.cpp
+++ b/mujoco_ros/src/mujoco_sim.cpp
@@ -337,6 +337,11 @@ void requestExternalShutdown(void)
 void resetSim()
 {
 	if (main_env_->model) {
+		// sim_mtx is already locked and we wait a little to ensure no old tf messages are being sent after the reset
+		ROS_DEBUG_NAMED("mujoco", "Sleeping to give tf message transport enough time");
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+		ROS_DEBUG_NAMED("mujoco", "Starting reset");
+
 		mj_resetData(main_env_->model.get(), main_env_->data.get());
 		loadInitialJointStates(main_env_->model, main_env_->data);
 		main_env_->reset();

--- a/mujoco_ros_control/src/mujoco_ros_control_plugin.cpp
+++ b/mujoco_ros_control/src/mujoco_ros_control_plugin.cpp
@@ -181,6 +181,8 @@ void MujocoRosControlPlugin::controlCallback(MujocoSim::mjModelPtr /*model*/, Mu
 void MujocoRosControlPlugin::reset()
 {
 	ROS_INFO("Resetting mujoco_ros_control");
+	last_update_sim_time_ros_ = ros::Time();
+	last_write_sim_time_ros_  = ros::Time();
 }
 
 std::string MujocoRosControlPlugin::getURDF(std::string param_name) const

--- a/mujoco_ros_control/src/mujoco_ros_control_plugin.cpp
+++ b/mujoco_ros_control/src/mujoco_ros_control_plugin.cpp
@@ -173,10 +173,10 @@ void MujocoRosControlPlugin::controlCallback(MujocoSim::mjModelPtr /*model*/, Mu
 		controller_manager_->update(sim_time_ros, sim_period, reset_ctrls);
 	}
 
-	if (last_update_sim_time_ros_.toNSec() > 0.0 && (sim_time_ros - last_write_sim_time_ros_).toNSec() > 0.0)
+	if (!last_update_sim_time_ros_.isZero() && (sim_time_ros > last_write_sim_time_ros_)) {
 		robot_hw_sim_->writeSim(sim_time_ros, sim_time_ros - last_write_sim_time_ros_);
-
-	last_write_sim_time_ros_ = sim_time_ros;
+		last_write_sim_time_ros_ = sim_time_ros;
+	}
 }
 
 void MujocoRosControlPlugin::reset() {}

--- a/mujoco_ros_control/src/mujoco_ros_control_plugin.cpp
+++ b/mujoco_ros_control/src/mujoco_ros_control_plugin.cpp
@@ -147,7 +147,13 @@ bool MujocoRosControlPlugin::load(MujocoSim::mjModelPtr m, MujocoSim::mjDataPtr 
 
 void MujocoRosControlPlugin::controlCallback(MujocoSim::mjModelPtr /*model*/, MujocoSim::mjDataPtr /*data*/)
 {
-	ros::Time sim_time_ros   = ros::Time::now();
+	ros::Time sim_time_ros = ros::Time::now();
+	if (sim_time_ros < last_update_sim_time_ros_) {
+		ROS_INFO_NAMED("mujoco_ros_control", "Resetting mujoco_ros_control due to time reset");
+		last_update_sim_time_ros_ = ros::Time();
+		last_write_sim_time_ros_  = ros::Time();
+	}
+
 	ros::Duration sim_period = sim_time_ros - last_update_sim_time_ros_;
 	bool reset_ctrls         = last_update_sim_time_ros_.isZero();
 
@@ -173,12 +179,7 @@ void MujocoRosControlPlugin::controlCallback(MujocoSim::mjModelPtr /*model*/, Mu
 	last_write_sim_time_ros_ = sim_time_ros;
 }
 
-void MujocoRosControlPlugin::reset()
-{
-	ROS_INFO("Resetting mujoco_ros_control");
-	last_update_sim_time_ros_ = ros::Time();
-	last_write_sim_time_ros_  = ros::Time();
-}
+void MujocoRosControlPlugin::reset() {}
 
 std::string MujocoRosControlPlugin::getURDF(std::string param_name) const
 {


### PR DESCRIPTION
> After some research, I found that if, and only if, /use_sim_time is set in the launch file before starting any node, the TF buffer is cleared upon a jump back in time and the joint_state_publisher node re-publishes joint transforms. However, control still seems unable to handle this.
I could not find the reason, but sometimes upon reset the robot stays in position, i.e. the controller sends a valid control signal, and sometimes the robot just drops to the floor without any signs of being actively controlled. Once the point in (ROS) time is reached, where the reset was previously issued, the robot starts being actuated again.

There were two remaining issues:
1. `reset_ctrls` wasn't initialized sometimes:
   https://github.com/ubi-agni/mujoco_ros_pkgs/blob/d4463dbf7ac5b7224c8f35ff8a341e39e27dfc39/mujoco_ros_control/src/mujoco_ros_control_plugin.cpp#L159
2. Resetting of controller times was done in main thread, while evaluation was done in another. This randomly resulted in the reset times being overwritten by the latter thread again, thus not causing a reset, but to a negative time difference, effectively disabled the call to `robot_hw_sim_->writeSim()`:
   https://github.com/ubi-agni/mujoco_ros_pkgs/blob/d4463dbf7ac5b7224c8f35ff8a341e39e27dfc39/mujoco_ros_control/src/mujoco_ros_control_plugin.cpp#L175-L176

> Occasionally `TF_OLD_DATA` and `TF_REPEATED_DATA` warnings are still thrown:
```
[ WARN] [1665881466.432722731] [ros.robot_state_publisher] [/robot_state_publisher]: Moved backwards in time: 1.668000000 -> 0.000000000 msg: 0.000000000
[ INFO] [1665881466.433811401] [ros.mujoco_ros_control.mujoco_ros_control] [/mujoco_server]: Resetting mujoco_ros_control due to time reset
[ WARN] [1665881466.440837947, 0.007000000] [ros.tf2_ros] [/mujoco_server]: Detected jump back in time of 1.652s. Clearing TF buffer.
[ WARN] [1665881468.112881338, 1.678000000] [ros.rosconsole_bridge.console_bridge] [/mujoco_server]: TF_REPEATED_DATA ignoring data with redundant timestamp for frame panda_leftfinger at time 1.667000 according to authority unknown_publisher
[ WARN] [1665881468.112925709, 1.678000000] [ros.rosconsole_bridge.console_bridge] [/mujoco_server]: TF_REPEATED_DATA ignoring data with redundant timestamp for frame panda_rightfinger at time 1.667000 according to authority unknown_publisher
[ WARN] [1665881468.112960183, 1.679000000] [ros.rosconsole_bridge.console_bridge] [/mujoco_server]: TF_REPEATED_DATA ignoring data with redundant timestamp for frame panda_link1 at time 1.667000 according to authority unknown_publisher
...
[ WARN] [1665881468.113142298, 1.680000000] [ros.rosconsole_bridge.console_bridge] [/mujoco_server]: TF_REPEATED_DATA ignoring data with redundant timestamp for frame panda_link7 at time 1.667000 according to authority unknown_publisher
```

I didn't manage to fix those yet. This seems to be a timing issue (of course). When compiling with `Debug` mode instead of `RelWithDebInfo` the error vanishes. All those messages originate from the `robot_state_publisher` processing the latest `joint_states` message before the time reset. But I don't see a reason (and evidence) that this message (and the triggered TF msgs) are published twice!