### PR TITLE
Fix findmujoco.cmake for build-installed mujoco

### DIFF
--- a/mujoco_ros/Findmujoco.cmake
+++ b/mujoco_ros/Findmujoco.cmake
@@ -1,4 +1,4 @@
-find_package(mujoco QUIET NO_MODULE)
+find_package(mujoco::mujoco QUIET NO_MODULE)
 
 if(NOT mujoco_FOUND)
 	# Find headers


### PR DESCRIPTION
With mujoco 2.2.2 built from scratch `find_package(mujoco REQUIRED)` does not return any errors, but no mujoco properties get set and building mujoco_ros fails.

Edit: My mistake, this actually just ensures the find_package call fails and triggers setting the properties manually, which does work in this case. Is there any reason to keep the first line and check for `mujoco_FOUND` or is there a case when this fails to resolve the properties correctly?