### PR TITLE
Fix publish rate of camera images

### DIFF
--- a/mujoco_ros/CHANGELOG.md
+++ b/mujoco_ros/CHANGELOG.md
@@ -9,7 +9,10 @@
 * Set GUI default to show info overlay and hide UI1.
 
 ### Fixed
+* Fixed publish rate of camera images (#22).
 * Now publishing clock on reload.
+
+Contributors: @DavidPL1, @lbergmann
 
 <a name="0.5.0"></a>
 ## [0.5.0] - 2023-03-24

--- a/mujoco_ros/src/rendering/utils.cpp
+++ b/mujoco_ros/src/rendering/utils.cpp
@@ -393,7 +393,7 @@ void offScreenRenderEnv(MujocoEnvPtr env)
 		env->vis_.cam.type       = mjCAMERA_FIXED;
 		env->vis_.cam.fixedcamid = stream->cam_id_;
 
-		if (ros::Duration(1 / stream->pub_freq_) >= ros::Time::now() - stream->last_pub_) {
+		if (ros::Duration(1 / stream->pub_freq_) > ros::Time::now() - stream->last_pub_) {
 			continue;
 		}
 


### PR DESCRIPTION
With a publish rate of 100 Hz, a new image should be published every 10ms. 
The desired publish rate is only achieved if `>=` is replaced with `>`, otherwise a new image is published every 11ms.