### PR TITLE
build: fix catkin lint errors

### DIFF
--- a/mujoco_ros/CMakeLists.txt
+++ b/mujoco_ros/CMakeLists.txt
@@ -10,21 +10,9 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-if(NOT CMAKE_CONFIGURATION_TYPES)
-  if(NOT CMAKE_BUILD_TYPE)
-    message(STATUS "Setting build type to 'Release' as none was specified.")
-    set(CMAKE_BUILD_TYPE
-        "Release"
-        CACHE STRING "Choose the type of build, recommanded options are: Debug or Release" FORCE
-    )
-  endif()
-  set(BUILD_TYPES
-      "Debug"
-      "Release"
-      "MinSizeRel"
-      "RelWithDebInfo"
-  )
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS ${BUILD_TYPES})
+if(NOT CMAKE_BUILD_TYPE)
+  message(STATUS "CMAKE_BUILD_TYPE not set. Defaulting to 'Release'.")
+  set(CMAKE_BUILD_TYPE Release)
 endif()
 
 set(OpenGL_GL_PREFERENCE GLVND)
@@ -113,7 +101,9 @@ catkin_package(
   INCLUDE_DIRS
     include
   LIBRARIES
-    ${PROJECT_NAME} ${mujoco_LIBRARIES}
+    ${PROJECT_NAME}
+  DEPENDS
+    mujoco
 )
 
 add_subdirectory(src)

--- a/mujoco_ros/CMakeLists.txt
+++ b/mujoco_ros/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 project(mujoco_ros VERSION 0.7.0 LANGUAGES CXX)
 
+#catkin_lint: ignore uninstalled_plugin
+
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
@@ -34,7 +36,7 @@ include(ProjectOption)
 # Find catkin macros and libraries
 # if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 # is used, also find other catkin packages
-find_package(catkin REQUIRED
+find_package(catkin REQUIRED COMPONENTS
     roscpp
     pluginlib
     mujoco_ros_msgs
@@ -110,7 +112,6 @@ catkin_package(
     moveit_ros_planning_interface
   INCLUDE_DIRS
     include
-    ${mujoco_INCLUDE_DIRS}
   LIBRARIES
     ${PROJECT_NAME} ${mujoco_LIBRARIES}
 )

--- a/mujoco_ros/include/mujoco_ros/plugin_utils.h
+++ b/mujoco_ros/include/mujoco_ros/plugin_utils.h
@@ -94,7 +94,7 @@ public:
 	 * @param[in] model pointer to mjModel.
 	 * @param[in] data pointer to mjData.
 	 */
-	virtual void controlCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data){};
+	virtual void controlCallback(mjModelPtr /*model*/, mjDataPtr /*data*/){};
 
 	/**
 	 * @brief Override this function to compute and apply custom passive (i.e. non-controlled) forces.
@@ -104,7 +104,7 @@ public:
 	 * @param[in] model pointer to mjModel.
 	 * @param[in] data pointer to mjData.
 	 */
-	virtual void passiveCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data){};
+	virtual void passiveCallback(mjModelPtr /*model*/, mjDataPtr /*data*/){};
 
 	/**
 	 * @brief Override this callback to add custom visualisations to the scene.
@@ -113,8 +113,7 @@ public:
 	 * @param[in] data pointer to mjData.
 	 * @param[in] scene pointer to mjvScene.
 	 */
-	virtual void renderCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data,
-	                            [[maybe_unused]] mjvScene *scene){};
+	virtual void renderCallback(mjModelPtr /*model*/, mjDataPtr /*data*/, mjvScene * /*scene*/){};
 
 	/**
 	 * @brief Override this callback to add custom behavior at the end of a mujoco_ros simulation step.
@@ -124,7 +123,7 @@ public:
 	 * @param[in] model pointer to mjModel.
 	 * @param[in] data pointer to mjData.
 	 */
-	virtual void lastStageCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data){};
+	virtual void lastStageCallback(mjModelPtr /*model*/, mjDataPtr /*data*/){};
 
 	/**
 	 * @brief Override this callback to add custom behavior when a geom has been changed in the model.
@@ -133,8 +132,7 @@ public:
 	 * @param[in] data pointer to mjData.
 	 * @param[in] geom_id id of the geom thas has been changed.
 	 */
-	virtual void onGeomChanged([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data,
-	                           [[maybe_unused]] const int geom_id){};
+	virtual void onGeomChanged(mjModelPtr /*model*/, mjDataPtr /*data*/, const int /*geom_id*/){};
 
 protected:
 	/**

--- a/mujoco_ros/src/CMakeLists.txt
+++ b/mujoco_ros/src/CMakeLists.txt
@@ -45,6 +45,8 @@ target_include_directories(${PROJECT_NAME}
   PUBLIC ${PROJECT_SOURCE_DIR}/include
   ${mujoco_include_DIRS}
   ${GLFW_INCLUDE_DIRS}
+  PRIVATE
+  ${catkin_INCLUDE_DIRS}
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/mujoco_ros/src/callbacks.cpp
+++ b/mujoco_ros/src/callbacks.cpp
@@ -161,8 +161,7 @@ bool MujocoEnv::setPauseCB(mujoco_ros_msgs::SetPause::Request &req, mujoco_ros_m
 	return true;
 }
 
-bool MujocoEnv::shutdownCB([[maybe_unused]] std_srvs::Empty::Request &req,
-                           [[maybe_unused]] std_srvs::Empty::Response &res)
+bool MujocoEnv::shutdownCB(std_srvs::Empty::Request & /*req*/, std_srvs::Empty::Response & /*res*/)
 {
 	ROS_DEBUG("Shutdown requested");
 	settings_.exit_request.store(1);
@@ -195,7 +194,7 @@ bool MujocoEnv::reloadCB(mujoco_ros_msgs::Reload::Request &req, mujoco_ros_msgs:
 	return true;
 }
 
-bool MujocoEnv::resetCB([[maybe_unused]] std_srvs::Empty::Request &req, [[maybe_unused]] std_srvs::Empty::Response &res)
+bool MujocoEnv::resetCB(std_srvs::Empty::Request & /*req*/, std_srvs::Empty::Response & /*res*/)
 {
 	ROS_DEBUG("Reset requested");
 	settings_.reset_request.store(1);

--- a/mujoco_ros/test/CMakeLists.txt
+++ b/mujoco_ros/test/CMakeLists.txt
@@ -44,11 +44,6 @@ add_dependencies(mujoco_ros_plugin_test
   ${catkin_EXPORTED_TARGETS}
 )
 
-target_include_directories(mujoco_ros_plugin_test
-  PUBLIC
-  ${catkin_INCLUDE_DIRS}
-)
-
 target_link_libraries(mujoco_ros_plugin_test
   GTest::gtest_main
   mujoco_ros

--- a/mujoco_ros/test/test_plugin/CMakeLists.txt
+++ b/mujoco_ros/test/test_plugin/CMakeLists.txt
@@ -1,11 +1,9 @@
-find_package(rostest REQUIRED)
-
 add_library(mujoco_testplugin
   test_plugin.cpp
 )
 target_link_libraries(mujoco_testplugin
   project_option
-  # project_warning
+  project_warning
   mujoco_ros
   ${catkin_LIBRARIES}
 )

--- a/mujoco_ros/test/test_plugin/test_plugin.cpp
+++ b/mujoco_ros/test/test_plugin/test_plugin.cpp
@@ -82,27 +82,29 @@ void TestPlugin::reset()
 	ran_reset.store(true);
 }
 
-void TestPlugin::controlCallback(mjModelPtr model, mjDataPtr data)
+void TestPlugin::controlCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data)
 {
 	ran_control_cb.store(true);
 }
 
-void TestPlugin::passiveCallback(mjModelPtr model, mjDataPtr data)
+void TestPlugin::passiveCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data)
 {
 	ran_passive_cb.store(true);
 }
 
-void TestPlugin::renderCallback(mjModelPtr model, mjDataPtr data, mjvScene *scene)
+void TestPlugin::renderCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data,
+                                [[maybe_unused]] mjvScene *scene)
 {
 	ran_render_cb.store(true);
 }
 
-void TestPlugin::lastStageCallback(mjModelPtr model, mjDataPtr data)
+void TestPlugin::lastStageCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data)
 {
 	ran_last_cb.store(true);
 }
 
-void TestPlugin::onGeomChanged(mjModelPtr model, mjDataPtr data, const int geom_id)
+void TestPlugin::onGeomChanged([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data,
+                               [[maybe_unused]] const int geom_id)
 {
 	ran_on_geom_changed_cb.store(true);
 }

--- a/mujoco_ros/test/test_plugin/test_plugin.cpp
+++ b/mujoco_ros/test/test_plugin/test_plugin.cpp
@@ -82,29 +82,27 @@ void TestPlugin::reset()
 	ran_reset.store(true);
 }
 
-void TestPlugin::controlCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data)
+void TestPlugin::controlCallback(mjModelPtr /*model*/, mjDataPtr /*data*/)
 {
 	ran_control_cb.store(true);
 }
 
-void TestPlugin::passiveCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data)
+void TestPlugin::passiveCallback(mjModelPtr /*model*/, mjDataPtr /*data*/)
 {
 	ran_passive_cb.store(true);
 }
 
-void TestPlugin::renderCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data,
-                                [[maybe_unused]] mjvScene *scene)
+void TestPlugin::renderCallback(mjModelPtr /*model*/, mjDataPtr /*data*/, mjvScene * /*scene*/)
 {
 	ran_render_cb.store(true);
 }
 
-void TestPlugin::lastStageCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data)
+void TestPlugin::lastStageCallback(mjModelPtr /*model*/, mjDataPtr /*data*/)
 {
 	ran_last_cb.store(true);
 }
 
-void TestPlugin::onGeomChanged([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data,
-                               [[maybe_unused]] const int geom_id)
+void TestPlugin::onGeomChanged(mjModelPtr /*model*/, mjDataPtr /*data*/, const /*int*/ geom_id)
 {
 	ran_on_geom_changed_cb.store(true);
 }

--- a/mujoco_ros/test/test_plugin/test_plugin.cpp
+++ b/mujoco_ros/test/test_plugin/test_plugin.cpp
@@ -102,7 +102,7 @@ void TestPlugin::lastStageCallback(mjModelPtr /*model*/, mjDataPtr /*data*/)
 	ran_last_cb.store(true);
 }
 
-void TestPlugin::onGeomChanged(mjModelPtr /*model*/, mjDataPtr /*data*/, const /*int*/ geom_id)
+void TestPlugin::onGeomChanged(mjModelPtr /*model*/, mjDataPtr /*data*/, const int /*geom_id*/)
 {
 	ran_on_geom_changed_cb.store(true);
 }

--- a/mujoco_ros/test/test_plugin/test_plugin.h
+++ b/mujoco_ros/test/test_plugin/test_plugin.h
@@ -49,13 +49,11 @@ public:
 	virtual ~TestPlugin() {}
 	virtual bool load(mjModelPtr m, mjDataPtr d) override;
 	virtual void reset() override;
-	virtual void controlCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data) override;
-	virtual void passiveCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data) override;
-	virtual void renderCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data,
-	                            [[maybe_unused]] mjvScene *scene) override;
-	virtual void lastStageCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data) override;
-	virtual void onGeomChanged([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data,
-	                           [[maybe_unused]] const int geom_id) override;
+	virtual void controlCallback(mjModelPtr model, mjDataPtr data) override;
+	virtual void passiveCallback(mjModelPtr model, mjDataPtr data) override;
+	virtual void renderCallback(mjModelPtr model, mjDataPtr data, mjvScene *scene) override;
+	virtual void lastStageCallback(mjModelPtr model, mjDataPtr data) override;
+	virtual void onGeomChanged(mjModelPtr model, mjDataPtr data, const int geom_id) override;
 
 	mjModelPtr m_;
 	mjDataPtr d_;

--- a/mujoco_ros/test/test_plugin/test_plugin.h
+++ b/mujoco_ros/test/test_plugin/test_plugin.h
@@ -49,11 +49,13 @@ public:
 	virtual ~TestPlugin() {}
 	virtual bool load(mjModelPtr m, mjDataPtr d) override;
 	virtual void reset() override;
-	virtual void controlCallback(mjModelPtr model, mjDataPtr data) override;
-	virtual void passiveCallback(mjModelPtr model, mjDataPtr data) override;
-	virtual void renderCallback(mjModelPtr model, mjDataPtr data, mjvScene *scene) override;
-	virtual void lastStageCallback(mjModelPtr model, mjDataPtr data) override;
-	virtual void onGeomChanged(mjModelPtr model, mjDataPtr data, const int geom_id) override;
+	virtual void controlCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data) override;
+	virtual void passiveCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data) override;
+	virtual void renderCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data,
+	                            [[maybe_unused]] mjvScene *scene) override;
+	virtual void lastStageCallback([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data) override;
+	virtual void onGeomChanged([[maybe_unused]] mjModelPtr model, [[maybe_unused]] mjDataPtr data,
+	                           [[maybe_unused]] const int geom_id) override;
 
 	mjModelPtr m_;
 	mjDataPtr d_;

--- a/mujoco_ros_control/CMakeLists.txt
+++ b/mujoco_ros_control/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.13)
 
 project(mujoco_ros_control)
 
@@ -7,15 +7,15 @@ set( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined"
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-
-# Disable optimization to prevent false-positives with memory analisys tools (e.g. asan or valgrind)
-if (ENABLE_SANITIZER OR NO_OPTIM)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -fno-inline")
-  set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+    message("${PROJECT_NAME}: You did not request a specific build type: Choosing 'Release' for maximum performance")
+    set(CMAKE_BUILD_TYPE Release)
 endif()
 
-if (ENABLE_SANITIZER)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+set(CMAKE_CXX_FLAGS_SANITIZE "-O0 -fno-inline -fno-omit-frame-pointer -fno-optimize-sibling-calls")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-inline")
+
+if (CMAKE_BUILD_TYPE STREQUAL "Sanitize")
   add_link_options(-fsanitize=address)
 endif()
 
@@ -59,19 +59,11 @@ include_directories(
 add_library(${PROJECT_NAME}
   src/mujoco_ros_control_plugin.cpp
 )
-target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
-  include
-  ${Boost_INCLUDE_DIRS}
-  ${catkin_INCLUDE_DIRS}
-)
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
 )
 
 add_library(default_mujoco_ros_robot_hw_sim src/default_robot_hw_sim.cpp)
-target_include_directories(default_mujoco_ros_robot_hw_sim SYSTEM PUBLIC
-  ${catkin_INCLUDE_DIRS}
-)
 target_link_libraries(default_mujoco_ros_robot_hw_sim
   ${catkin_LIBRARIES}
 )

--- a/mujoco_ros_control/CMakeLists.txt
+++ b/mujoco_ros_control/CMakeLists.txt
@@ -7,17 +7,12 @@ set( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined"
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-    message("${PROJECT_NAME}: You did not request a specific build type: Choosing 'Release' for maximum performance")
-    set(CMAKE_BUILD_TYPE Release)
+if(NOT CMAKE_BUILD_TYPE)
+  message(STATUS "CMAKE_BUILD_TYPE not set. Defaulting to 'Release'.")
+  set(CMAKE_BUILD_TYPE Release)
 endif()
 
-set(CMAKE_CXX_FLAGS_SANITIZE "-O0 -fno-inline -fno-omit-frame-pointer -fno-optimize-sibling-calls")
-set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-inline")
-
-if (CMAKE_BUILD_TYPE STREQUAL "Sanitize")
-  add_link_options(-fsanitize=address)
-endif()
+set(CMAKE_CXX_FLAGS_SANITIZE "-fsanitize=address -g -O1 -fno-inline -fno-omit-frame-pointer -fno-optimize-sibling-calls")
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp

--- a/mujoco_ros_sensors/CMakeLists.txt
+++ b/mujoco_ros_sensors/CMakeLists.txt
@@ -1,18 +1,18 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.13)
 project(mujoco_ros_sensors)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-
-# Disable optimization to prevent false-positives with memory analisys tools (e.g. asan or valgrind)
-if (ENABLE_SANITIZER OR NO_OPTIM)
-  set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -O0 -fno-inline")
-  set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+    message("${PROJECT_NAME}: You did not request a specific build type: Choosing 'Release' for maximum performance")
+    set(CMAKE_BUILD_TYPE Release)
 endif()
 
-if (ENABLE_SANITIZER)
-  set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")
+set(CMAKE_CXX_FLAGS_SANITIZE "${CMAKE_CXX_FLAGS} -O0 -fno-inline -fno-omit-frame-pointer -fno-optimize-sibling-calls")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -O0 -fno-inline")
+
+if (CMAKE_BUILD_TYPE STREQUAL Sanitize)
   add_link_options(-fsanitize=address)
 endif()
 
@@ -51,10 +51,6 @@ include_directories(
 
 add_library(${PROJECT_NAME}
   src/mujoco_sensor_handler_plugin.cpp
-)
-target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
-  include
-  ${catkin_INCLUDE_DIRS}
 )
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}

--- a/mujoco_ros_sensors/CMakeLists.txt
+++ b/mujoco_ros_sensors/CMakeLists.txt
@@ -4,17 +4,12 @@ project(mujoco_ros_sensors)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-    message("${PROJECT_NAME}: You did not request a specific build type: Choosing 'Release' for maximum performance")
-    set(CMAKE_BUILD_TYPE Release)
+if(NOT CMAKE_BUILD_TYPE)
+  message(STATUS "CMAKE_BUILD_TYPE not set. Defaulting to 'Release'.")
+  set(CMAKE_BUILD_TYPE Release)
 endif()
 
-set(CMAKE_CXX_FLAGS_SANITIZE "${CMAKE_CXX_FLAGS} -O0 -fno-inline -fno-omit-frame-pointer -fno-optimize-sibling-calls")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -O0 -fno-inline")
-
-if (CMAKE_BUILD_TYPE STREQUAL Sanitize)
-  add_link_options(-fsanitize=address)
-endif()
+set(CMAKE_CXX_FLAGS_SANITIZE "-fsanitize=address -g -O1 -fno-inline -fno-omit-frame-pointer -fno-optimize-sibling-calls")
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/mujoco_ros_sensors/package.xml
+++ b/mujoco_ros_sensors/package.xml
@@ -18,6 +18,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
 
+  <test_depend>rostest</test_depend>
 
   <export>
     <mujoco_ros plugin="${prefix}/mujoco_ros_sensors_plugin.xml" />


### PR DESCRIPTION
* cleanup test_plugin cmake
* cleanup mujoco_ros_control cmake
  - Effects of NO_OPTIM flag moved to default Debug build.
  - Adds new CMAKE_BUILD_TYPE "Sanitize" in favor of dropping NO_OPTIM and SANITIZE flags.
  - Fixed catkin lint errors for this sub-package
* cleanup mujoco_ros_sensors cmake
  - Effect of NO_OPTIM flag moved to default Debug build.
  - Adds new CMAKE_BUILD_TYPE "Sanitize" in favor of dropping NO_OPTIM and
  - SANITIZE flags.
  - Fixed catkin lint errors for this sub-package.