### PR TITLE
syncronize camera_info with images

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get -q update && \
     apt-get -q -y dist-upgrade && \
     # Install common dependencies
     DEBIAN_FRONTEND=noninteractive apt-get -q install --no-install-recommends -y \
+        libgles2-mesa-dev libosmesa6-dev libglfw3-dev \
         curl git sudo python3-vcstool \
         $(test "${ROS_DISTRO}" = "noetic" && echo "python3-catkin-tools" || echo "python3-colcon-common-extensions") \
         clang clang-format clang-tidy clang-tools \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         distro: [noetic, one]
+        render_backend: [USE_GLFW, USE_OSMESA, USE_EGL]
         mujoco: [3.2.0]
         include:
           - distro: noetic
@@ -32,6 +33,15 @@ jobs:
             mujoco: 3.2.0
             env:
               CLANG_TIDY: pedantic
+        exclude:
+          - distro: one
+            render_backend: USE_EGL # requires GPU
+          - distro: one
+            render_backend: USE_GLFW # requires Xvfb
+          - distro: noetic
+            render_backend: USE_GLFW
+          - distro: noetic
+            render_backend: USE_EGL
 
     env:
       BUILDER: colcon
@@ -55,6 +65,7 @@ jobs:
       TARGET_CMAKE_ARGS: >
         -DCMAKE_BUILD_TYPE=${{ matrix.env.CCOV && 'Debug' || 'Release'}}
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS${{ matrix.env.CCOV && ' --coverage -O2 -fno-omit-frame-pointer'}}"
+        -D${{ matrix.render_backend }}=ON
       UPSTREAM_CMAKE_ARGS: -DCMAKE_CXX_FLAGS= -DCMAKE_CXX_STANDARD=17
 
       CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -69,7 +80,7 @@ jobs:
       CATKIN_LINT: ${{ matrix.env.CATKIN_LINT || 'false' }}
       CCOV: ${{ matrix.env.CCOV || 'false' }}
 
-    name: "${{ matrix.distro }} mj-${{ matrix.mujoco }}${{ matrix.env.CATKIN_LINT && ' + catkin_lint' || ''}}${{ matrix.env.CCOV && ' + ccov' || ''}}${{ matrix.env.CLANG_TIDY && (github.event_name != 'workflow_dispatch' && ' + clang-tidy (delta)' || ' + clang-tidy (all)') || '' }}"
+    name: "${{ matrix.distro }} mj-${{ matrix.mujoco }} ${{ matrix.render_backend }} ${{ matrix.env.CATKIN_LINT && ' + catkin_lint' || ''}}${{ matrix.env.CCOV && ' + ccov' || ''}}${{ matrix.env.CLANG_TIDY && (github.event_name != 'workflow_dispatch' && ' + clang-tidy (delta)' || ' + clang-tidy (all)') || '' }}"
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -114,7 +125,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure() && (steps.ici.outputs.run_target_test || steps.ici.outputs.target_test_results)
         with:
-          name: test-results-${{ matrix.distro }}
+          name: test-results-${{ matrix.distro }}-${{ matrix.render_backend }}
           path: ${{ env.BASEDIR }}/target_ws/**/test_results/**/*.xml
       - name: Generate codecov report
         uses: rhaschke/lcov-action@main
@@ -123,11 +134,12 @@ jobs:
           docker: $DOCKER_IMAGE
           workdir: ${{ env.BASEDIR }}/target_ws
           ignore: '"*/target_ws/build/*" "*/target_ws/install/*" "*/test/*"'
+          output: ${{ env.BASEDIR }}/target_ws/coverage-${{ matrix.distro }}-${{ matrix.render_backend }}.info
       - name: Upload codecov report
         uses: codecov/codecov-action@v5
         if: always() && matrix.env.CCOV && steps.ici.outputs.target_test_results == '0'
         with:
-          files: ${{ env.BASEDIR }}/target_ws/coverage.info
+          files: ${{ env.BASEDIR }}/target_ws/coverage-${{ matrix.distro }}-${{ matrix.render_backend }}.info
       - name: Upload clang-tidy changes
         uses: rhaschke/upload-git-patch-action@main
         if: always() && matrix.env.CLANG_TIDY

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
       TARGET_CMAKE_ARGS: >
         -DCMAKE_BUILD_TYPE=${{ matrix.env.CCOV && 'Debug' || 'Release'}}
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS${{ matrix.env.CCOV && ' --coverage -O2 -fno-omit-frame-pointer'}}"
-        -D${{ matrix.render_backend }}=ON
+        -DRENDER_BACKEND=${{ matrix.render_backend }}
       UPSTREAM_CMAKE_ARGS: -DCMAKE_CXX_FLAGS= -DCMAKE_CXX_STANDARD=17
 
       CCACHE_DIR: ${{ github.workspace }}/.ccache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Loading and reset times are reported in the server debug log. All plugin stats c
 * Re-added services for getting and setting gravity, that somehow vanished.
 * Fixed flaky tests that did not consider control callbacks being called in paused mode, too (#40).
 * Fixed bug that would not allow breaking out of *as fast as possible* stepping in headless mode without shutting down the simulation.
+* Fixed occasional segfault when offscreen context was freed on shutdown.
 
 ### Changed
 * Moved `mujoco_ros::Viewer::Clock` definition to `mujoco_ros::Clock` (into common_types.h).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Loading and reset times are reported in the server debug log. All plugin stats c
 * Increased test coverage of `mujoco_ros_sensors` plugin.
 * Split monolithic ros interface tests into more individual tests.
 * Added sleeping at least until the next lowerbound GUI refresh when paused to reduce cpu load.
+* deprecated `no_x` launchparameter in favor of using `no_render`, as offscreen rendering now is also available without X.
 
 Contributors: @DavidPL1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Loading and reset times are reported in the server debug log. All plugin stats c
 * Fixed flaky tests that did not consider control callbacks being called in paused mode, too (#40).
 * Fixed bug that would not allow breaking out of *as fast as possible* stepping in headless mode without shutting down the simulation.
 * Fixed occasional segfault when offscreen context was freed on shutdown.
+* Fixed segmented image never being rendered/published.
 
 ### Changed
 * Moved `mujoco_ros::Viewer::Clock` definition to `mujoco_ros::Clock` (into common_types.h).
@@ -28,6 +29,7 @@ Loading and reset times are reported in the server debug log. All plugin stats c
 * Split monolithic ros interface tests into more individual tests.
 * Added sleeping at least until the next lowerbound GUI refresh when paused to reduce cpu load.
 * deprecated `no_x` launchparameter in favor of using `no_render`, as offscreen rendering now is also available without X.
+* Optimized camera render configurations where RGB, Segmented and Depth streams are active, but only Segmented and Depth are subscribed. Previously, this would result in two separate low-level render calls, now it's done in one.
 
 Contributors: @DavidPL1
 

--- a/mujoco_ros/CMakeLists.txt
+++ b/mujoco_ros/CMakeLists.txt
@@ -21,6 +21,10 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 include(ProjectOption)
 
+option(NO_GLFW "Disable GLFW3 support and try finding OpenGL EGL or OSMESA for offscreen rendering" OFF)
+option(USE_EGL "Build with EGL enabled offscreen rendering. Entails `NO_GLFW`" OFF)
+option(USE_OSMESA "Build with OSMESA enabled offscreen rendering. Entails `NO_GLFW`" OFF)
+
 # Find catkin macros and libraries
 # if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 # is used, also find other catkin packages
@@ -60,7 +64,35 @@ configure_project_option(
 
 # Find MuJoCo
 find_package(mujoco 3.2.0 REQUIRED)
-find_library(GLFW libglfw.so.3)
+find_library(GLFW libglfw.so.3) # Find GLFW3 for GUI
+
+
+if (NO_GLFW OR USE_EGL OR USE_OSMESA OR ${GLFW} STREQUAL "GLFW-NOTFOUND")
+  message(WARNING "GLFW3 not found or disabled. GUI will not be available.")
+
+  find_package(OpenGL COMPONENTS OpenGL EGL) # Find OpenGL (EGL) for offscreen rendering
+  if (USE_OSMESA OR ${OpenGL_EGL_FOUND} STREQUAL "FALSE")
+    message(WARNING "EGL not found or disabled. Falling back to OSMESA.")
+
+    find_package(OSMesa)
+
+    if (!OSMesa_FOUND)
+      message(WARNING "EGL disabled or not found and OSMesa could not be found. Offscreen rendering will not be available!")
+    else() # OSMesa found
+      set(RENDERING_BACKEND "USE_OSMESA")
+      message(STATUS "OSMesa found. Offscreen rendering available.")
+    endif()
+
+  else() # EGL found
+    set(RENDERING_BACKEND "USE_EGL")
+    message(STATUS "EGL found. Offscreen rendering available.")
+  endif()
+
+else() # GLFW found
+  set(RENDERING_BACKEND "USE_GLFW")
+  message(STATUS "GLFW3 found. GUI and offscreen rendering available.")
+endif()
+
 
 # ###############################################
 # # Declare ROS dynamic reconfigure parameters ##

--- a/mujoco_ros/CMakeLists.txt
+++ b/mujoco_ros/CMakeLists.txt
@@ -18,12 +18,14 @@ endif()
 set(OpenGL_GL_PREFERENCE GLVND)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# Ensure generated header path exists both with catkin and colcon
+# catkin defines CATKIN_DEVEL_PREFIX, colcon does not define it
+if(NOT DEFINED CATKIN_DEVEL_PREFIX)
+ set(CATKIN_DEVEL_PREFIX ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 include(ProjectOption)
-
-option(NO_GLFW "Disable GLFW3 support and try finding OpenGL EGL or OSMESA for offscreen rendering" OFF)
-option(USE_EGL "Build with EGL enabled offscreen rendering. Entails `NO_GLFW`" OFF)
-option(USE_OSMESA "Build with OSMESA enabled offscreen rendering. Entails `NO_GLFW`" OFF)
 
 # Find catkin macros and libraries
 # if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
@@ -64,35 +66,6 @@ configure_project_option(
 
 # Find MuJoCo
 find_package(mujoco 3.2.0 REQUIRED)
-find_library(GLFW libglfw.so.3) # Find GLFW3 for GUI
-
-
-if (NO_GLFW OR USE_EGL OR USE_OSMESA OR ${GLFW} STREQUAL "GLFW-NOTFOUND")
-  message(WARNING "GLFW3 not found or disabled. GUI will not be available.")
-
-  find_package(OpenGL COMPONENTS OpenGL EGL) # Find OpenGL (EGL) for offscreen rendering
-  if (USE_OSMESA OR ${OpenGL_EGL_FOUND} STREQUAL "FALSE")
-    message(WARNING "EGL not found or disabled. Falling back to OSMESA.")
-
-    find_package(OSMesa)
-
-    if (!OSMesa_FOUND)
-      message(WARNING "EGL disabled or not found and OSMesa could not be found. Offscreen rendering will not be available!")
-    else() # OSMesa found
-      set(RENDERING_BACKEND "USE_OSMESA")
-      message(STATUS "OSMesa found. Offscreen rendering available.")
-    endif()
-
-  else() # EGL found
-    set(RENDERING_BACKEND "USE_EGL")
-    message(STATUS "EGL found. Offscreen rendering available.")
-  endif()
-
-else() # GLFW found
-  set(RENDERING_BACKEND "USE_GLFW")
-  message(STATUS "GLFW3 found. GUI and offscreen rendering available.")
-endif()
-
 
 # ###############################################
 # # Declare ROS dynamic reconfigure parameters ##
@@ -112,6 +85,7 @@ endif()
 generate_dynamic_reconfigure_options(
   cfg/SimParams.cfg
 )
+include(ConfigureRenderBackend)
 
 # ##################################
 # # catkin specific configuration ##
@@ -148,6 +122,8 @@ add_subdirectory(src)
 
 # Depend on gencfg to ensure build before lib
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
+# Depend on render_backend_h to ensure build before lib
+add_dependencies(${PROJECT_NAME} render_backend_h)
 
 # ############
 # # Install ##

--- a/mujoco_ros/cmake/ConfigureRenderBackend.cmake
+++ b/mujoco_ros/cmake/ConfigureRenderBackend.cmake
@@ -1,0 +1,79 @@
+include_guard()
+
+find_library(GLFW libglfw.so.3) # Find GLFW3 for GUI
+
+set(RENDER_BACKEND "ANY" CACHE STRING "Choose rendering backend")
+set_property(CACHE RENDER_BACKEND PROPERTY STRINGS "ANY" "USE_GLFW" "USE_EGL" "USE_OSMESA")
+message(message "configured RENDER_BACKEND: ${RENDER_BACKEND}")
+
+if (RENDER_BACKEND STREQUAL "ANY")
+  unset(NO_GLFW)
+  unset(NO_EGL)
+  unset(NO_OSMESA)
+endif()
+
+if (RENDER_BACKEND STREQUAL "USE_GLFW")
+  set(NO_EGL ON)
+  set(NO_OSMESA ON)
+  message(STATUS "EGL and OSMESA disabled!")
+endif()
+
+if (RENDER_BACKEND STREQUAL "USE_EGL")
+  set(NO_GLFW ON)
+  message(STATUS "GLFW disabled! Will use OSMesa as fallback if EGL can not be found.")
+endif()
+
+if (RENDER_BACKEND STREQUAL "USE_OSMESA")
+  set(NO_GLFW ON)
+  set(NO_EGL ON)
+  message(STATUS "GLFW and EGL disabled!")
+endif()
+
+if (NO_GLFW OR ${GLFW} STREQUAL "GLFW-NOTFOUND")
+  message(WARNING "GLFW3 not found or disabled. GUI will not be available.")
+
+  find_package(OpenGL COMPONENTS OpenGL EGL) # Find OpenGL (EGL) for offscreen rendering
+  if (NO_EGL OR ${OpenGL_EGL_FOUND} STREQUAL "FALSE")
+    message(WARNING "EGL not found or disabled. Falling back to OSMESA.")
+
+    find_package(OSMesa)
+
+    if (NO_OSMESA OR !OSMesa_FOUND)
+      message(WARNING "EGL disabled or not found and OSMesa could not be found. Offscreen rendering will not be available!")
+      set(RENDERING_BACKEND "USE_NONE")
+    else() # OSMesa found
+      set(RENDERING_BACKEND "USE_OSMESA")
+      message(STATUS "OSMesa found. Offscreen rendering available.")
+    endif()
+
+  else() # EGL found
+    set(RENDERING_BACKEND "USE_EGL")
+    message(STATUS "EGL found. Offscreen rendering available.")
+  endif()
+
+else() # GLFW found
+  set(RENDERING_BACKEND "USE_GLFW")
+  message(STATUS "GLFW3 found. GUI and offscreen rendering available.")
+endif()
+
+add_custom_command(
+  OUTPUT ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/render_backend.h always_rebuild
+  COMMAND ${CMAKE_COMMAND}
+  -DRENDER_BACKEND=${RENDERING_BACKEND}
+  -DHEADER_FILE_PATH=${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/GenerateBackendHeader.cmake
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+add_custom_target(render_backend_h
+ DEPENDS always_rebuild
+)
+
+list(APPEND ${PROJECT_NAME}_INCLUDE_DIRS
+  ${CATKIN_DEVEL_PREFIX}/include
+)
+
+# Install header file
+# catkin_lint: ignore_once external_file
+install(FILES ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/render_backend.h
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)

--- a/mujoco_ros/cmake/FindOSMesa.cmake
+++ b/mujoco_ros/cmake/FindOSMesa.cmake
@@ -1,0 +1,60 @@
+#########
+# Taken from https://github.com/Kitware/VTK/blob/master/CMake/FindOSMesa.cmake
+#########
+
+# Try to find Mesa off-screen library and include dir.
+# Once done this will define
+#
+# OSMesa_FOUND        - true if OSMesa has been found
+# OSMesa_INCLUDE_DIRS - where the GL/osmesa.h can be found
+# OSMesa_LIBRARIES    - Link this to use OSMesa
+# OSMesa_VERSION      - Version of OSMesa found
+# OSMesa::OSMesa      - Imported target
+
+find_path(OSMESA_INCLUDE_DIR
+  NAMES GL/osmesa.h
+  PATHS "${OSMESA_ROOT}/include"
+        "$ENV{OSMESA_ROOT}/include"
+        /usr/openwin/share/include
+        /opt/graphics/OpenGL/include
+  DOC   "OSMesa include directory")
+mark_as_advanced(OSMESA_INCLUDE_DIR)
+
+find_library(OSMESA_LIBRARY
+  NAMES OSMesa OSMesa16 OSMesa32
+  PATHS "${OSMESA_ROOT}/lib"
+        "$ENV{OSMESA_ROOT}/lib"
+        /opt/graphics/OpenGL/lib
+        /usr/openwin/lib
+  DOC   "OSMesa library")
+mark_as_advanced(OSMESA_LIBRARY)
+
+if (OSMESA_INCLUDE_DIR AND EXISTS "${OSMESA_INCLUDE_DIR}/GL/osmesa.h")
+  file(STRINGS "${OSMESA_INCLUDE_DIR}/GL/osmesa.h" _OSMesa_version_lines
+    REGEX "OSMESA_[A-Z]+_VERSION")
+  string(REGEX REPLACE ".*# *define +OSMESA_MAJOR_VERSION +([0-9]+).*" "\\1" _OSMesa_version_major "${_OSMesa_version_lines}")
+  string(REGEX REPLACE ".*# *define +OSMESA_MINOR_VERSION +([0-9]+).*" "\\1" _OSMesa_version_minor "${_OSMesa_version_lines}")
+  string(REGEX REPLACE ".*# *define +OSMESA_PATCH_VERSION +([0-9]+).*" "\\1" _OSMesa_version_patch "${_OSMesa_version_lines}")
+  set(OSMesa_VERSION "${_OSMesa_version_major}.${_OSMesa_version_minor}.${_OSMesa_version_patch}")
+  unset(_OSMesa_version_major)
+  unset(_OSMesa_version_minor)
+  unset(_OSMesa_version_patch)
+  unset(_OSMesa_version_lines)
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OSMesa
+  REQUIRED_VARS OSMESA_INCLUDE_DIR OSMESA_LIBRARY
+  VERSION_VAR OSMesa_VERSION)
+
+if (OSMesa_FOUND)
+  set(OSMesa_INCLUDE_DIRS "${OSMESA_INCLUDE_DIR}")
+  set(OSMesa_LIBRARIES "${OSMESA_LIBRARY}")
+
+  if (NOT TARGET OSMesa::OSMesa)
+    add_library(OSMesa::OSMesa UNKNOWN IMPORTED)
+    set_target_properties(OSMesa::OSMesa PROPERTIES
+      IMPORTED_LOCATION "${OSMESA_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${OSMESA_INCLUDE_DIR}")
+  endif ()
+endif ()

--- a/mujoco_ros/cmake/Findmujoco.cmake
+++ b/mujoco_ros/cmake/Findmujoco.cmake
@@ -22,7 +22,7 @@ if(NOT mujoco_FOUND)
 	# Find dependencies
 	cmake_policy(SET CMP0072 NEW)
 	include(CMakeFindDependencyMacro)
-	find_dependency(OpenGL REQUIRED)
+	find_package(OpenGL)
 
 	if(mujoco_INCLUDE_DIRS AND mujoco_LIBRARIES)
 		set(mujoco_FOUND TRUE)

--- a/mujoco_ros/cmake/GenerateBackendHeader.cmake
+++ b/mujoco_ros/cmake/GenerateBackendHeader.cmake
@@ -1,0 +1,6 @@
+# Generate header file with rendering backend definition
+file(MAKE_DIRECTORY ${HEADER_FILE_PATH})
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/render_backend.h.in
+  ${HEADER_FILE_PATH}/render_backend.h
+)

--- a/mujoco_ros/cmake/render_backend.h.in
+++ b/mujoco_ros/cmake/render_backend.h.in
@@ -1,0 +1,8 @@
+#ifndef RENDER_BACKEND
+#define USE_GLFW 3
+#define USE_EGL 2
+#define USE_OSMESA 1
+#define USE_NONE 0
+
+#define RENDER_BACKEND ${RENDER_BACKEND}
+#endif

--- a/mujoco_ros/include/mujoco_ros/common_types.h
+++ b/mujoco_ros/include/mujoco_ros/common_types.h
@@ -41,8 +41,6 @@
 #include <ros/ros.h>
 #include <image_transport/image_transport.h>
 
-#include <GLFW/glfw3.h>
-
 namespace mujoco_ros {
 
 using Clock = std::chrono::steady_clock;

--- a/mujoco_ros/include/mujoco_ros/mujoco_env.h
+++ b/mujoco_ros/include/mujoco_ros/mujoco_env.h
@@ -341,9 +341,9 @@ protected:
 
 	void notifyGeomChanged(const int geom_id);
 
+	boost::recursive_mutex sim_params_mutex_;
 	dynamic_reconfigure::Server<mujoco_ros::SimParamsConfig> *param_server_;
 	mujoco_ros::SimParamsConfig sim_params_;
-	boost::recursive_mutex sim_params_mutex_;
 	void dynparamCallback(mujoco_ros::SimParamsConfig &config, uint32_t level);
 	void updateDynamicParams();
 

--- a/mujoco_ros/include/mujoco_ros/mujoco_env.h
+++ b/mujoco_ros/include/mujoco_ros/mujoco_env.h
@@ -90,8 +90,12 @@
 
 #include <rosgraph_msgs/Clock.h>
 
+#if defined(USE_GLFW)
 #include <mujoco_ros/glfw_adapter.h>
 #include <mujoco_ros/glfw_dispatch.h>
+#elif defined(USE_OSMESA)
+#include <GL/osmesa.h>
+#endif
 
 namespace mujoco_ros {
 
@@ -116,7 +120,15 @@ struct OffscreenRenderContext
 	mjvCamera cam;
 	std::unique_ptr<unsigned char[]> rgb;
 	std::unique_ptr<float[]> depth;
+#ifdef USE_GLFW
 	std::shared_ptr<GLFWwindow> window;
+#elif defined(USE_OSMESA)
+	struct
+	{
+		OSMesaContext ctx;
+		unsigned char buffer[10000000]; // TODO: size necessary or resize later?
+	} osmesa;
+#endif
 	mjrContext con = {};
 	mjvScene scn   = {};
 
@@ -268,7 +280,13 @@ public:
 
 	bool togglePaused(bool paused, const std::string &admin_hash = std::string());
 
+#if defined(USE_GLFW)
 	GlfwAdapter *gui_adapter_ = nullptr;
+#endif
+
+#if defined(USE_EGL) || defined(USE_OSMESA)
+	bool InitGL();
+#endif
 
 	void runRenderCbs(mjvScene *scene);
 	bool step(int num_steps = 1, bool blocking = true);

--- a/mujoco_ros/include/mujoco_ros/mujoco_env.h
+++ b/mujoco_ros/include/mujoco_ros/mujoco_env.h
@@ -128,6 +128,7 @@ struct OffscreenRenderContext
 	{
 		OSMesaContext ctx;
 		unsigned char buffer[10000000]; // TODO: size necessary or resize later?
+		bool initialized = false;
 	} osmesa;
 #endif
 	mjrContext con = {};

--- a/mujoco_ros/include/mujoco_ros/mujoco_env.h
+++ b/mujoco_ros/include/mujoco_ros/mujoco_env.h
@@ -55,6 +55,7 @@
 
 #include <boost/thread.hpp>
 
+#include <mujoco_ros/render_backend.h>
 #include <mujoco_ros/common_types.h>
 #include <mujoco_ros/viewer.h>
 #include <mujoco_ros/plugin_utils.h>
@@ -90,10 +91,10 @@
 
 #include <rosgraph_msgs/Clock.h>
 
-#if defined(USE_GLFW)
+#if RENDER_BACKEND == USE_GLFW
 #include <mujoco_ros/glfw_adapter.h>
 #include <mujoco_ros/glfw_dispatch.h>
-#elif defined(USE_OSMESA)
+#elif RENDER_BACKEND == USE_OSMESA
 #include <GL/osmesa.h>
 #endif
 
@@ -120,9 +121,9 @@ struct OffscreenRenderContext
 	mjvCamera cam;
 	std::unique_ptr<unsigned char[]> rgb;
 	std::unique_ptr<float[]> depth;
-#ifdef USE_GLFW
+#if RENDER_BACKEND == USE_GLFW
 	std::shared_ptr<GLFWwindow> window;
-#elif defined(USE_OSMESA)
+#elif RENDER_BACKEND == USE_OSMESA
 	struct
 	{
 		OSMesaContext ctx;
@@ -280,11 +281,11 @@ public:
 
 	bool togglePaused(bool paused, const std::string &admin_hash = std::string());
 
-#if defined(USE_GLFW)
+#if RENDER_BACKEND == USE_GLFW
 	GlfwAdapter *gui_adapter_ = nullptr;
 #endif
 
-#if defined(USE_EGL) || defined(USE_OSMESA)
+#if RENDER_BACKEND == USE_EGL || RENDER_BACKEND == USE_OSMESA
 	bool InitGL();
 #endif
 

--- a/mujoco_ros/include/mujoco_ros/offscreen_camera.h
+++ b/mujoco_ros/include/mujoco_ros/offscreen_camera.h
@@ -53,10 +53,11 @@ namespace mujoco_ros::rendering {
 class OffscreenCamera
 {
 public:
-	OffscreenCamera(const uint8_t cam_id, const std::string &cam_name, const int width, const int height,
-	                const streamType stream_type, const bool use_segid, const float pub_freq,
-	                image_transport::ImageTransport *it, const ros::NodeHandle &parent_nh, const mjModel *model,
-	                mjData *data, mujoco_ros::MujocoEnv *env_ptr);
+	OffscreenCamera(const uint8_t cam_id, const std::string &base_topic, const std::string &rgb_topic,
+	                const std::string &depth_topic, const std::string &segment_topic, const std::string &cam_name,
+	                const int width, const int height, const streamType stream_type, const bool use_segid,
+	                const float pub_freq, const ros::NodeHandle &parent_nh, const mjModel *model, mjData *data,
+	                mujoco_ros::MujocoEnv *env_ptr);
 
 	~OffscreenCamera()
 	{
@@ -66,11 +67,14 @@ public:
 		rgb_pub_.shutdown();
 		depth_pub_.shutdown();
 		segment_pub_.shutdown();
-		camera_info_pub_.shutdown();
+		rgb_camera_info_pub_.shutdown();
+		depth_camera_info_pub_.shutdown();
+		segment_camera_info_pub_.shutdown();
 	};
 
 	uint8_t cam_id_;
 	std::string cam_name_;
+	std::string topic_;
 	int width_, height_;
 	streamType stream_type_ = streamType::RGB;
 	bool use_segid_         = true;
@@ -82,10 +86,14 @@ public:
 	mjvSceneState scn_state_; // Update depends on vopt, so every CamStream needs one
 
 	ros::Time last_pub_;
-	ros::Publisher camera_info_pub_;
+	ros::NodeHandle nh_;
+	image_transport::ImageTransport it_;
 	image_transport::Publisher rgb_pub_;
+	ros::Publisher rgb_camera_info_pub_;
 	image_transport::Publisher depth_pub_;
+	ros::Publisher depth_camera_info_pub_;
 	image_transport::Publisher segment_pub_;
+	ros::Publisher segment_camera_info_pub_;
 
 	void renderAndPublish(mujoco_ros::OffscreenRenderContext *offscreen);
 
@@ -97,8 +105,6 @@ public:
 
 private:
 	std::unique_ptr<camera_info_manager::CameraInfoManager> camera_info_manager_;
-
-	void publishCameraInfo();
 
 	bool renderAndPubIfNecessary(mujoco_ros::OffscreenRenderContext *offscreen, const bool rgb, const bool depth,
 	                             const bool segment);

--- a/mujoco_ros/launch/launch_server.launch
+++ b/mujoco_ros/launch/launch_server.launch
@@ -7,7 +7,8 @@
   <arg name="unpause"              default="false" doc="Whether the simulation should be unpaused on start." />
   <arg name="headless"             default="false" />
   <arg name="render_offscreen"     default="true"  doc="Whether offscreen rendering should be enabled." />
-  <arg name="no_x"                 default="false" doc="Set to true to enable running on a server without X, disabling everything related to OpenGL rendering."/>
+  <arg name="no_x"                 default=""      doc="Set to true to enable running on a server without X, disabling everything related to OpenGL rendering. (deprecated)"/>
+  <arg name="no_render"            default="false" doc="Set to true to disabling rendering on- and off screen. (shorthand for render_offscreen:=false headless:=true)"/>
   <arg name="eval_mode"            default="false" doc="Whether to run mujoco_ros in evaluation mode." />
   <arg name="admin_hash"           default="''"    doc="Hash to verify critical operations in evaluation mode." />
   <arg name="debug"                default="false" doc="Whether to run with gdb." />
@@ -45,6 +46,7 @@
         <param name="headless"             value="$(arg headless)" />
         <param name="render_offscreen"     value="$(arg render_offscreen)" />
         <param name="no_x"                 value="$(arg no_x)" />
+        <param name="no_render"            value="$(arg no_render)" />
         <param name="num_steps"            value="$(arg num_sim_steps)" />
         <param name="eval_mode"            value="$(arg eval_mode)" />
         <param name="modelfile"            value="$(arg modelfile)" />
@@ -61,6 +63,7 @@
         <param name="headless"             value="$(arg headless)" />
         <param name="render_offscreen"     value="$(arg render_offscreen)" />
         <param name="no_x"                 value="$(arg no_x)" />
+        <param name="no_render"            value="$(arg no_render)" />
         <param name="num_steps"            value="$(arg num_sim_steps)" />
         <param name="eval_mode"            value="$(arg eval_mode)" />
         <param name="modelfile"            value="$(arg modelfile)" />
@@ -80,6 +83,7 @@
         <param name="headless"             value="$(arg headless)" />
         <param name="render_offscreen"     value="$(arg render_offscreen)" />
         <param name="no_x"                 value="$(arg no_x)" />
+        <param name="no_render"            value="$(arg no_render)" />
         <param name="num_steps"            value="$(arg num_sim_steps)" />
         <param name="eval_mode"            value="$(arg eval_mode)" />
         <param name="modelfile"            value="$(arg modelfile)" />
@@ -99,6 +103,7 @@
         <param name="headless"             value="$(arg headless)" />
         <param name="render_offscreen"     value="$(arg render_offscreen)" />
         <param name="no_x"                 value="$(arg no_x)" />
+        <param name="no_render"            value="$(arg no_render)" />
         <param name="num_steps"            value="$(arg num_sim_steps)" />
         <param name="eval_mode"            value="$(arg eval_mode)" />
         <param name="modelfile"            value="$(arg modelfile)" />

--- a/mujoco_ros/src/CMakeLists.txt
+++ b/mujoco_ros/src/CMakeLists.txt
@@ -9,30 +9,32 @@ target_include_directories(lodepng PRIVATE
 target_link_libraries(lodepng PRIVATE project_option)
 add_library(mujoco_ros::lodepng ALIAS lodepng)
 
-add_library(platform_ui_adapter OBJECT
-  $<TARGET_OBJECTS:lodepng>
-  glfw_adapter.cc
-  glfw_dispatch.cc
-  platform_ui_adapter.cc
-)
-set_property(TARGET platform_ui_adapter PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_include_directories(platform_ui_adapter PUBLIC
-  ${PROJECT_SOURCE_DIR}/include
-  ${GLFW_INTERFACE_INCLUDE_DIRECTORIES}
-)
-target_link_libraries(platform_ui_adapter
-  PUBLIC
-    mujoco::mujoco
-    ${GLFW}
-  PRIVATE
-    mujoco_ros::lodepng
-    project_option
-    project_warning
-)
-add_library(mujoco_ros::platform_ui_adapter ALIAS platform_ui_adapter)
+if(RENDERING_BACKEND STREQUAL "USE_GLFW")
+  add_library(platform_ui_adapter OBJECT
+    $<TARGET_OBJECTS:lodepng>
+    glfw_adapter.cc
+    glfw_dispatch.cc
+    platform_ui_adapter.cc
+  )
+  set_property(TARGET platform_ui_adapter PROPERTY POSITION_INDEPENDENT_CODE ON)
+  target_include_directories(platform_ui_adapter PUBLIC
+    ${PROJECT_SOURCE_DIR}/include
+    ${GLFW_INTERFACE_INCLUDE_DIRECTORIES}
+  )
+  target_link_libraries(platform_ui_adapter
+    PUBLIC
+      mujoco::mujoco
+      ${GLFW}
+    PRIVATE
+      mujoco_ros::lodepng
+      project_option
+      project_warning
+  )
+  add_library(mujoco_ros::platform_ui_adapter ALIAS platform_ui_adapter)
+endif()
 
 add_library(${PROJECT_NAME}
-  $<TARGET_OBJECTS:platform_ui_adapter>
+  $<TARGET_OBJECTS:lodepng>
   mujoco_env.cpp
   viewer.cpp
   plugin_utils.cpp
@@ -41,6 +43,14 @@ add_library(${PROJECT_NAME}
   callbacks.cpp
   physics.cpp
 )
+
+if(RENDERING_BACKEND STREQUAL "USE_GLFW")
+  target_sources(${PROJECT_NAME} PRIVATE $<TARGET_OBJECTS:platform_ui_adapter>)
+endif()
+
+if (RENDERING_BACKEND)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC ${RENDERING_BACKEND}=1)
+endif()
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC ${PROJECT_SOURCE_DIR}/include
@@ -53,13 +63,19 @@ target_include_directories(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
    mujoco::mujoco
-   mujoco_ros::platform_ui_adapter
    catkin_pkg
   PRIVATE
-   mujoco_ros::lodepng
    project_option
    project_warning
 )
+
+if(RENDERING_BACKEND STREQUAL "USE_GLFW")
+  target_link_libraries(${PROJECT_NAME} PUBLIC mujoco_ros::platform_ui_adapter)
+elseif(RENDERING_BACKEND STREQUAL "USE_EGL")
+  target_link_libraries(${PROJECT_NAME} PUBLIC OpenGL::EGL)
+elseif(RENDERING_BACKEND STREQUAL "USE_OSMESA")
+  target_link_libraries(${PROJECT_NAME} PUBLIC OSMesa::OSMesa)
+endif()
 
 # Node Executable
 add_executable(mujoco_node

--- a/mujoco_ros/src/main.cpp
+++ b/mujoco_ros/src/main.cpp
@@ -138,13 +138,6 @@ int main(int argc, char **argv)
 	// TODO(dleins): Should MuJoCo Plugins be loaded?
 	env = std::make_unique<mujoco_ros::MujocoEnv>(admin_hash);
 
-	bool no_x;
-	nh.param("no_x", no_x, false);
-
-	if (!no_x) {
-		nh.param("headless", no_x, false);
-	}
-
 	// const char *filename = nullptr;
 	if (!filename.empty()) {
 		mju::strcpy_arr(env->queued_filename_, filename.c_str());
@@ -154,7 +147,7 @@ int main(int argc, char **argv)
 	env->startPhysicsLoop();
 	env->startEventLoop();
 
-	if (!no_x) {
+	if (!env->settings_.headless) {
 		// mjvCamera cam;
 		// mjvOption opt;
 		// mjv_defaultCamera(&cam);

--- a/mujoco_ros/src/main.cpp
+++ b/mujoco_ros/src/main.cpp
@@ -34,7 +34,6 @@
 
 /* Authors: David P. Leins */
 
-#include <mujoco_ros/glfw_adapter.h>
 #include <mujoco_ros/viewer.h>
 #include <mujoco_ros/mujoco_env.h>
 
@@ -44,6 +43,10 @@
 #include <boost/program_options.hpp>
 #include <csignal>
 #include <thread>
+
+#if defined(USE_GLFW)
+#include <mujoco_ros/glfw_adapter.h>
+#endif
 
 namespace {
 
@@ -147,19 +150,19 @@ int main(int argc, char **argv)
 	env->startPhysicsLoop();
 	env->startEventLoop();
 
+#ifdef USE_GLFW
 	if (!env->settings_.headless) {
-		// mjvCamera cam;
-		// mjvOption opt;
-		// mjv_defaultCamera(&cam);
-		// mjv_defaultOption(&opt);
 		ROS_INFO("Launching viewer");
-		auto viewer =
-		    // std::make_unique<mujoco_ros::Viewer>(std::unique_ptr<mujoco_ros::PlatformUIAdapter>(env->gui_adapter_),
-		    //                                      env.get(), &cam, &opt, /* is_passive = */ false);
-		    std::make_unique<mujoco_ros::Viewer>(std::unique_ptr<mujoco_ros::PlatformUIAdapter>(env->gui_adapter_),
-		                                         env.get(), /* is_passive = */ false);
+		auto viewer = std::make_unique<mujoco_ros::Viewer>(
+		    std::unique_ptr<mujoco_ros::PlatformUIAdapter>(env->gui_adapter_), env.get(), /* is_passive = */ false);
 		viewer->RenderLoop();
-	} else {
+	}
+#else
+	if (!env->settings_.headless) {
+		ROS_ERROR("GLFW backend not available. Cannot launch viewer");
+	}
+#endif
+	else {
 		ROS_INFO("Running headless");
 	}
 

--- a/mujoco_ros/src/main.cpp
+++ b/mujoco_ros/src/main.cpp
@@ -34,7 +34,8 @@
 
 /* Authors: David P. Leins */
 
-#include <mujoco_ros/viewer.h>
+#include <mujoco_ros/render_backend.h>
+
 #include <mujoco_ros/mujoco_env.h>
 
 #include <mujoco_ros/array_safety.h>
@@ -44,8 +45,9 @@
 #include <csignal>
 #include <thread>
 
-#if defined(USE_GLFW)
+#if RENDER_BACKEND == USE_GLFW
 #include <mujoco_ros/glfw_adapter.h>
+#include <mujoco_ros/viewer.h>
 #endif
 
 namespace {
@@ -150,7 +152,7 @@ int main(int argc, char **argv)
 	env->startPhysicsLoop();
 	env->startEventLoop();
 
-#ifdef USE_GLFW
+#if RENDER_BACKEND == USE_GLFW
 	if (!env->settings_.headless) {
 		ROS_INFO("Launching viewer");
 		auto viewer = std::make_unique<mujoco_ros::Viewer>(

--- a/mujoco_ros/src/mujoco_env.cpp
+++ b/mujoco_ros/src/mujoco_env.cpp
@@ -43,11 +43,11 @@
 #include <stdexcept>
 #include <sstream>
 
-#if defined(USE_GLFW)
+#if RENDER_BACKEND == USE_GLFW
 static std::string render_backend = "GLFW";
-#elif defined(USE_OSMESA)
+#elif RENDER_BACKEND == USE_OSMESA
 static std::string render_backend = "OSMESA";
-#elif defined(USE_EGL)
+#elif RENDER_BACKEND == USE_EGL
 static std::string render_backend = "EGL";
 #else
 static std::string render_backend = "NONE. No offscreen rendering available.";
@@ -59,7 +59,7 @@ namespace mju = ::mujoco::sample_util;
 using Seconds      = std::chrono::duration<double>;
 using Milliseconds = std::chrono::duration<double, std::milli>;
 
-#ifdef USE_GLFW
+#if RENDER_BACKEND == USE_GLFW
 namespace {
 int MaybeGlfwInit()
 {
@@ -137,7 +137,7 @@ MujocoEnv::MujocoEnv(const std::string &admin_hash /* = std::string()*/)
 
 	nh_->param<bool>("headless", settings_.headless, true);
 	if (!settings_.headless) {
-#if defined(USE_GLFW)
+#if RENDER_BACKEND == USE_GLFW
 		gui_adapter_ = new mujoco_ros::GlfwAdapter();
 #else
 		ROS_ERROR("Compiled without GLFW support. Cannot run in non-headless mode.");
@@ -160,10 +160,10 @@ MujocoEnv::MujocoEnv(const std::string &admin_hash /* = std::string()*/)
 	if (settings_.render_offscreen) {
 		bool can_render = true;
 
-#if defined(USE_GLFW)
+#if RENDER_BACKEND == USE_GLFW
 		can_render = MaybeGlfwInit();
 		ROS_ERROR_COND(!can_render, "Failed to initialize GLFW. Cannot render offscreen!");
-#elif !defined(USE_EGL) && !defined(USE_OSMESA)
+#elif RENDER_BACKEND == NONE
 		ROS_ERROR("No rendering backend available. Cannot render offscreen!");
 		can_render = false;
 #endif

--- a/mujoco_ros/src/mujoco_env.cpp
+++ b/mujoco_ros/src/mujoco_env.cpp
@@ -607,6 +607,9 @@ void MujocoEnv::loadWithModelAndData()
 	model_.reset(mnew, mj_deleteModel);
 	data_.reset(dnew, mj_deleteData);
 
+	// perform a forward pass to initialize all fields if not done yet (very important for offscreen rendering)
+	mj_forward(model_.get(), data_.get());
+
 	if (model_->opt.integrator == mjINT_EULER) {
 		ROS_WARN("Euler integrator detected. Euler is default for legacy reasons, consider using implicitfast, which is "
 		         "recommended for most applications.");

--- a/mujoco_ros/src/mujoco_env.cpp
+++ b/mujoco_ros/src/mujoco_env.cpp
@@ -131,7 +131,7 @@ MujocoEnv::MujocoEnv(const std::string &admin_hash /* = std::string()*/)
 	}
 
 	nh_->param<bool>("render_offscreen", settings_.render_offscreen, true);
-	if (!settings_.render_offscreen) {
+	if (settings_.render_offscreen) {
 		mjv_makeScene(nullptr, &offscreen_.scn, Viewer::kMaxGeom);
 	}
 

--- a/mujoco_ros/src/offscreen_camera.cpp
+++ b/mujoco_ros/src/offscreen_camera.cpp
@@ -196,7 +196,7 @@ bool OffscreenCamera::renderAndPubIfNecessary(mujoco_ros::OffscreenRenderContext
 	} else { // depth only
 		mjr_readPixels(nullptr, offscreen->depth.get(), viewport, &offscreen->con);
 	}
-#ifdef USE_GLFW
+#if RENDER_BACKEND == USE_GLFW
 	glfwSwapBuffers(offscreen->window.get());
 #endif
 

--- a/mujoco_ros/src/offscreen_camera.cpp
+++ b/mujoco_ros/src/offscreen_camera.cpp
@@ -192,7 +192,9 @@ bool OffscreenCamera::renderAndPubIfNecessary(mujoco_ros::OffscreenRenderContext
 	} else if (depth) {
 		mjr_readPixels(nullptr, offscreen->depth.get(), viewport, &offscreen->con);
 	}
+#ifdef USE_GLFW
 	glfwSwapBuffers(offscreen->window.get());
+#endif
 
 	if (rgb) {
 		// Publish RGB image

--- a/mujoco_ros/src/offscreen_camera.cpp
+++ b/mujoco_ros/src/offscreen_camera.cpp
@@ -55,6 +55,7 @@ OffscreenCamera::OffscreenCamera(const uint8_t cam_id, const std::string &base_t
                                  mujoco_ros::MujocoEnv *env_ptr)
     : cam_id_(cam_id)
     , cam_name_(cam_name)
+    , topic_(base_topic)
     , width_(width)
     , height_(height)
     , stream_type_(stream_type)

--- a/mujoco_ros/src/offscreen_camera.cpp
+++ b/mujoco_ros/src/offscreen_camera.cpp
@@ -47,10 +47,12 @@
 
 namespace mujoco_ros::rendering {
 
-OffscreenCamera::OffscreenCamera(const uint8_t cam_id, const std::string &cam_name, const int width, const int height,
+OffscreenCamera::OffscreenCamera(const uint8_t cam_id, const std::string &base_topic, const std::string &rgb_topic,
+                                 const std::string &depth_topic, const std::string &segment_topic,
+                                 const std::string &cam_name, const int width, const int height,
                                  const streamType stream_type, const bool use_segid, const float pub_freq,
-                                 image_transport::ImageTransport *it, const ros::NodeHandle &parent_nh,
-                                 const mjModel *model, mjData *data, mujoco_ros::MujocoEnv *env_ptr)
+                                 const ros::NodeHandle &parent_nh, const mjModel *model, mjData *data,
+                                 mujoco_ros::MujocoEnv *env_ptr)
     : cam_id_(cam_id)
     , cam_name_(cam_name)
     , width_(width)
@@ -58,9 +60,10 @@ OffscreenCamera::OffscreenCamera(const uint8_t cam_id, const std::string &cam_na
     , stream_type_(stream_type)
     , use_segid_(use_segid)
     , pub_freq_(pub_freq)
+    , nh_(parent_nh, base_topic)
+    , it_(nh_)
 {
 	last_pub_ = ros::Time::now();
-	ros::NodeHandle nh(parent_nh, "cameras/" + cam_name);
 
 	mjv_defaultOption(&vopt_);
 	mjv_defaultSceneState(&scn_state_);
@@ -68,15 +71,18 @@ OffscreenCamera::OffscreenCamera(const uint8_t cam_id, const std::string &cam_na
 
 	if (stream_type & streamType::RGB) {
 		ROS_DEBUG_NAMED("mujoco_env", "\tCreating rgb publisher");
-		rgb_pub_ = it->advertise("cameras/" + cam_name + "/rgb", 1);
+		rgb_pub_             = it_.advertise(rgb_topic + "/image_raw", 1);
+		rgb_camera_info_pub_ = nh_.advertise<sensor_msgs::CameraInfo>(rgb_topic + "/camera_info", 1, true);
 	}
 	if (stream_type & streamType::DEPTH) {
 		ROS_DEBUG_NAMED("mujoco_env", "\tCreating depth publisher");
-		depth_pub_ = it->advertise("cameras/" + cam_name + "/depth", 1);
+		depth_pub_             = it_.advertise(depth_topic + "/image_raw", 1);
+		depth_camera_info_pub_ = nh_.advertise<sensor_msgs::CameraInfo>(depth_topic + "/camera_info", 1, true);
 	}
 	if (stream_type & streamType::SEGMENTED) {
 		ROS_DEBUG_NAMED("mujoco_env", "\tCreating segmentation publisher");
-		segment_pub_ = it->advertise("cameras/" + cam_name + "/segmented", 1);
+		segment_pub_             = it_.advertise(segment_topic + "/image_raw", 1);
+		segment_camera_info_pub_ = nh_.advertise<sensor_msgs::CameraInfo>(segment_topic + "/camera_info", 1, true);
 	}
 
 	ROS_DEBUG_STREAM_NAMED("mujoco_env", "\tSetting up camera stream(s) of type '"
@@ -120,7 +126,7 @@ OffscreenCamera::OffscreenCamera(const uint8_t cam_id, const std::string &cam_na
 	env_ptr->registerStaticTransform(cam_transform);
 
 	// init camera info manager
-	camera_info_manager_ = std::make_unique<camera_info_manager::CameraInfoManager>(nh, cam_name);
+	camera_info_manager_ = std::make_unique<camera_info_manager::CameraInfoManager>(nh_, cam_name);
 
 	// Get camera info
 	mjtNum cam_pos[3];
@@ -153,7 +159,6 @@ OffscreenCamera::OffscreenCamera(const uint8_t cam_id, const std::string &cam_na
 	mju_copy(ci.K.c_array() + 6, extrinsic + 8, 3);
 
 	camera_info_manager_->setCameraInfo(ci);
-	camera_info_pub_ = nh.advertise<sensor_msgs::CameraInfo>("camera_info", 1, true);
 }
 
 bool OffscreenCamera::shouldRender(const ros::Time &t)
@@ -194,11 +199,16 @@ bool OffscreenCamera::renderAndPubIfNecessary(mujoco_ros::OffscreenRenderContext
 	glfwSwapBuffers(offscreen->window.get());
 #endif
 
+	// create info msg
+	auto ros_time                           = ros::Time(scn_state_.data.time);
+	sensor_msgs::CameraInfo camera_info_msg = camera_info_manager_->getCameraInfo();
+	camera_info_msg.header.stamp            = ros_time;
+
 	if (rgb_or_s) {
 		// Publish RGB image
 		sensor_msgs::ImagePtr rgb_msg = boost::make_shared<sensor_msgs::Image>();
 		rgb_msg->header.frame_id      = cam_name_ + "_optical_frame";
-		rgb_msg->header.stamp         = ros::Time(scn_state_.data.time);
+		rgb_msg->header.stamp         = ros_time;
 		rgb_msg->width                = static_cast<decltype(rgb_msg->width)>(viewport.width);
 		rgb_msg->height               = static_cast<decltype(rgb_msg->height)>(viewport.height);
 		rgb_msg->encoding             = sensor_msgs::image_encodings::RGB8;
@@ -216,8 +226,10 @@ bool OffscreenCamera::renderAndPubIfNecessary(mujoco_ros::OffscreenRenderContext
 
 		if (segment) {
 			segment_pub_.publish(rgb_msg);
+			segment_camera_info_pub_.publish(camera_info_msg);
 		} else {
 			rgb_pub_.publish(rgb_msg);
+			rgb_camera_info_pub_.publish(camera_info_msg);
 		}
 	}
 
@@ -225,7 +237,7 @@ bool OffscreenCamera::renderAndPubIfNecessary(mujoco_ros::OffscreenRenderContext
 		// Publish DEPTH image
 		sensor_msgs::ImagePtr depth_msg = boost::make_shared<sensor_msgs::Image>();
 		depth_msg->header.frame_id      = cam_name_ + "_optical_frame";
-		depth_msg->header.stamp         = ros::Time(scn_state_.data.time);
+		depth_msg->header.stamp         = ros_time;
 		depth_msg->width                = util::as_unsigned(viewport.width);
 		depth_msg->height               = util::as_unsigned(viewport.height);
 		depth_msg->encoding             = sensor_msgs::image_encodings::TYPE_32FC1;
@@ -249,7 +261,9 @@ bool OffscreenCamera::renderAndPubIfNecessary(mujoco_ros::OffscreenRenderContext
 		}
 
 		depth_pub_.publish(depth_msg);
+		depth_camera_info_pub_.publish(camera_info_msg);
 	}
+
 	return true;
 }
 
@@ -261,12 +275,14 @@ void OffscreenCamera::renderAndPublish(mujoco_ros::OffscreenRenderContext *offsc
 
 	initial_published_ = true;
 
-	last_pub_     = ros::Time(scn_state_.data.time);
-	bool rendered = false;
+	last_pub_ = ros::Time(scn_state_.data.time);
 
-	bool segment = stream_type_ & streamType::SEGMENTED && segment_pub_.getNumSubscribers() > 0;
-	bool rgb     = stream_type_ & streamType::RGB && rgb_pub_.getNumSubscribers() > 0;
-	bool depth   = stream_type_ & streamType::DEPTH && depth_pub_.getNumSubscribers() > 0;
+	bool segment = (stream_type_ & streamType::SEGMENTED) &&
+	               (segment_pub_.getNumSubscribers() > 0 || segment_camera_info_pub_.getNumSubscribers() > 0);
+	bool rgb = (stream_type_ & streamType::RGB) &&
+	           (rgb_pub_.getNumSubscribers() > 0 || rgb_camera_info_pub_.getNumSubscribers() > 0);
+	bool depth = (stream_type_ & streamType::DEPTH) &&
+	             (depth_pub_.getNumSubscribers() > 0 || depth_camera_info_pub_.getNumSubscribers() > 0);
 
 	offscreen->cam.fixedcamid = cam_id_;
 
@@ -274,26 +290,14 @@ void OffscreenCamera::renderAndPublish(mujoco_ros::OffscreenRenderContext *offsc
 	// flag).
 	if (rgb && segment) { // first render RGB and maybe DEPTH, then SEGMENTED
 		offscreen->scn.flags[mjRND_SEGMENT] = 0;
-		rendered                            = renderAndPubIfNecessary(offscreen, true, depth, false);
+		renderAndPubIfNecessary(offscreen, true, depth, false);
 
 		offscreen->scn.flags[mjRND_SEGMENT] = 1;
-		rendered                            = renderAndPubIfNecessary(offscreen, false, false, true) || rendered;
+		renderAndPubIfNecessary(offscreen, false, false, true);
 	} else { // render maybe RGB/SEGMENTED and maybe DEPTH
 		offscreen->scn.flags[mjRND_SEGMENT] = segment;
-		rendered                            = renderAndPubIfNecessary(offscreen, rgb, depth, segment);
+		renderAndPubIfNecessary(offscreen, rgb, depth, segment);
 	}
-
-	if (rendered) {
-		publishCameraInfo();
-	}
-}
-
-void OffscreenCamera::publishCameraInfo()
-{
-	sensor_msgs::CameraInfo camera_info_msg = camera_info_manager_->getCameraInfo();
-	camera_info_msg.header.stamp            = ros::Time::now();
-
-	camera_info_pub_.publish(camera_info_msg);
 }
 
 } // namespace mujoco_ros::rendering

--- a/mujoco_ros/src/offscreen_rendering.cpp
+++ b/mujoco_ros/src/offscreen_rendering.cpp
@@ -305,8 +305,10 @@ void MujocoEnv::offscreenRenderLoop()
 			// Wait for render request
 			std::unique_lock<std::mutex> lock(offscreen_.render_mutex);
 			// ROS_DEBUG_NAMED("offscreen_rendering", "Waiting for render request");
-			offscreen_.cond_render_request.wait(
-			    lock, [this] { return offscreen_.request_pending.load() || settings_.visual_init_request.load(); });
+			offscreen_.cond_render_request.wait(lock, [this] {
+				return offscreen_.request_pending.load() || settings_.visual_init_request.load() ||
+				       settings_.exit_request.load();
+			});
 
 			// In case of exit request after waiting for render request
 			if (!ros::ok() || settings_.exit_request.load()) {
@@ -317,6 +319,7 @@ void MujocoEnv::offscreenRenderLoop()
 				ROS_DEBUG_NAMED("offscreen_rendering", "Initializing render resources");
 				initializeRenderResources();
 				settings_.visual_init_request = false;
+				continue;
 			}
 
 			for (const auto &cam_ptr : offscreen_.cams) {

--- a/mujoco_ros/src/offscreen_rendering.cpp
+++ b/mujoco_ros/src/offscreen_rendering.cpp
@@ -40,7 +40,7 @@
 
 #include <sstream>
 
-#ifdef USE_EGL
+#if RENDER_BACKEND == USE_EGL
 #include <EGL/egl.h>
 #endif
 
@@ -48,7 +48,7 @@ namespace mujoco_ros {
 
 OffscreenRenderContext::~OffscreenRenderContext()
 {
-#if defined(USE_GLFW)
+#if RENDER_BACKEND == USE_GLFW
 	if (window != nullptr) {
 		ROS_DEBUG("Freeing GLFW offscreen context");
 		std::unique_lock<std::mutex> lock(render_mutex);
@@ -56,7 +56,7 @@ OffscreenRenderContext::~OffscreenRenderContext()
 		mjr_defaultContext(&con);
 		mjr_freeContext(&con);
 	}
-#elif defined(USE_EGL)
+#elif RENDER_BACKEND == USE_EGL
 	ROS_DEBUG("Freeing EGL offscreen context");
 	mjr_defaultContext(&con);
 	mjr_freeContext(&con);
@@ -76,7 +76,7 @@ OffscreenRenderContext::~OffscreenRenderContext()
 		// Terminate display
 		eglTerminate(display);
 	}
-#elif defined(USE_OSMESA)
+#elif RENDER_BACKEND == USE_OSMESA
 	ROS_DEBUG("Freeing OSMESA offscreen context");
 	mjr_defaultContext(&con);
 	mjr_freeContext(&con);
@@ -164,7 +164,7 @@ void MujocoEnv::initializeRenderResources()
 
 	ROS_DEBUG_NAMED("offscreen_rendering", "Initializing offscreen rendering utils");
 
-#ifdef USE_GLFW
+#if RENDER_BACKEND == USE_GLFW
 	Glfw().glfwMakeContextCurrent(offscreen_.window.get());
 	// Glfw().glfwSetWindowSize(offscreen_.window.get(), max_res_w, max_res_h);
 	glfwSetWindowSize(offscreen_.window.get(), max_res_w, max_res_h);
@@ -176,7 +176,7 @@ void MujocoEnv::initializeRenderResources()
 	mjr_setBuffer(mjFB_OFFSCREEN, &offscreen_.con);
 }
 
-#if defined(USE_EGL)
+#if RENDER_BACKEND == USE_EGL
 bool MujocoEnv::InitGL()
 {
 	ROS_DEBUG("Initializing EGL...");
@@ -238,7 +238,7 @@ bool MujocoEnv::InitGL()
 	ROS_DEBUG("EGL initialized");
 	return true;
 }
-#elif defined(USE_OSMESA)
+#elif RENDER_BACKEND == USE_OSMESA
 bool MujocoEnv::InitGL()
 {
 	ROS_DEBUG("Initializing OSMesa...");
@@ -262,7 +262,7 @@ bool MujocoEnv::InitGL()
 
 void MujocoEnv::offscreenRenderLoop()
 {
-#if defined(USE_GLFW)
+#if RENDER_BACKEND == USE_GLFW
 	Glfw().glfwWindowHint(GLFW_DOUBLEBUFFER, GLFW_FALSE);
 	Glfw().glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
 	offscreen_.window.reset(Glfw().glfwCreateWindow(800, 600, "Invisible window", nullptr, nullptr),
@@ -278,12 +278,12 @@ void MujocoEnv::offscreenRenderLoop()
 
 	Glfw().glfwMakeContextCurrent(offscreen_.window.get());
 	Glfw().glfwSwapInterval(0);
-#elif defined(USE_EGL)
+#elif RENDER_BACKEND == USE_EGL
 	if (!InitGL()) {
 		ROS_ERROR("Failed to initialize EGL. Cannot run offscreen rendering");
 		return;
 	}
-#elif defined(USE_OSMESA)
+#elif RENDER_BACKEND == USE_OSMESA
 	if (!InitGL()) {
 		ROS_ERROR("Failed to initialize OSMesa. Cannot run offscreen rendering");
 		return;

--- a/mujoco_ros/src/offscreen_rendering.cpp
+++ b/mujoco_ros/src/offscreen_rendering.cpp
@@ -45,9 +45,10 @@ namespace mujoco_ros {
 OffscreenRenderContext::~OffscreenRenderContext()
 {
 	if (window != nullptr) {
-		// Making context current before calling mjr_freeContext causes a bad access error
-		// Let glfwTerminate() handle the cleanup then
 		ROS_DEBUG("Freeing offscreen context");
+		std::unique_lock<std::mutex> lock(render_mutex);
+		request_pending.store(false);
+		mjr_defaultContext(&con);
 		mjr_freeContext(&con);
 	}
 }

--- a/mujoco_ros/src/offscreen_rendering.cpp
+++ b/mujoco_ros/src/offscreen_rendering.cpp
@@ -243,7 +243,7 @@ bool MujocoEnv::InitGL()
 {
 	ROS_DEBUG("Initializing OSMesa...");
 	// Initialize OSMesa
-	offscreen_.osmesa.ctx = OSMesaCreateContextExt(GL_RGBA, 24, 8, 8, 0);
+	offscreen_.osmesa.ctx = OSMesaCreateContextExt(GL_RGBA, 24, 8, 8, nullptr);
 	if (!offscreen_.osmesa.ctx) {
 		ROS_ERROR("OSMesa context creation failed");
 		return false;

--- a/mujoco_ros/src/offscreen_rendering.cpp
+++ b/mujoco_ros/src/offscreen_rendering.cpp
@@ -77,6 +77,9 @@ OffscreenRenderContext::~OffscreenRenderContext()
 		eglTerminate(display);
 	}
 #elif RENDER_BACKEND == USE_OSMESA
+	if (!osmesa.initialized) {
+		return;
+	}
 	ROS_DEBUG("Freeing OSMESA offscreen context");
 	mjr_defaultContext(&con);
 	mjr_freeContext(&con);
@@ -256,6 +259,7 @@ bool MujocoEnv::InitGL()
 		return false;
 	}
 	ROS_DEBUG("OSMesa initialized");
+	offscreen_.osmesa.initialized = true;
 	return true;
 } // InitGL
 #endif

--- a/mujoco_ros/src/physics.cpp
+++ b/mujoco_ros/src/physics.cpp
@@ -83,7 +83,6 @@ void MujocoEnv::physicsLoop()
 	ROS_INFO_COND(num_steps_until_exit_ == 0, "Reached requested number of steps. Exiting simulation");
 	// settings_.exit_request.store(1);
 	if (offscreen_.render_thread_handle.joinable()) {
-		offscreen_.request_pending.store(true);
 		offscreen_.cond_render_request.notify_one();
 		ROS_DEBUG("Joining offscreen render thread");
 		offscreen_.render_thread_handle.join();

--- a/mujoco_ros/test/CMakeLists.txt
+++ b/mujoco_ros/test/CMakeLists.txt
@@ -51,7 +51,25 @@ target_link_libraries(mujoco_ros_plugin_test
   project_warning
 )
 
+add_rostest_gtest(mujoco_render_test
+  launch/mujoco_render.test
+  mujoco_render_test.cpp
+)
+
+add_dependencies(mujoco_render_test
+  ${${PROJECT_NAME}_EXPORTED_TARGETS}
+  ${catkin_EXPORTED_TARGETS}
+)
+
+target_link_libraries(mujoco_render_test
+  mujoco_ros
+  project_option
+  project_warning
+)
+
 install(FILES
   empty_world.xml
+  equality_world.xml
+  camera_world.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test
 )

--- a/mujoco_ros/test/camera_world.xml
+++ b/mujoco_ros/test/camera_world.xml
@@ -1,0 +1,45 @@
+<mujoco model="3DOF">
+    <option timestep="0.001" gravity="0 0 -9.81" cone="elliptic" />
+    <compiler angle="radian" />
+
+    <visual>
+        <headlight ambient="0.4 0.4 0.4" diffuse="0.4 0.4 0.4" specular="0.0 0.0 0.0" active="1" />
+    </visual>
+
+    <asset>
+        <texture builtin="checker" height="512" name="texplane" rgb1=".2 .3 .4" rgb2=".1 .15 .2" type="2d" width="512" />
+        <material name="MatPlane" reflectance="0.5" shininess="0.01" specular="0.1" texrepeat="1 1" texture="texplane" texuniform="true" />
+    </asset>
+
+    <worldbody>
+        <light pos="0 0 1000" castshadow="false" />
+        <geom name="ground_plane" type="plane" size="5 5 10" material="MatPlane" rgba="1 1 1 1"/>
+
+        <body name="base_link">
+            <geom name="capsule1" type="capsule" fromto="0 0 1  0 0 0.6" size="0.06"/>
+            <joint name="balljoint" type="ball" pos="0 0 1"/>
+            <body name="middle_link">
+                <geom name="capsule2" type="capsule" fromto="0 0 0.6  0.0 0 0.3" size="0.04"/>
+                <joint name="joint1" type="hinge" pos="0 0 0.6" axis="0 1 0"/>
+                <!-- <joint name="joint2" type="hinge" pos="0 0 0.6" axis="1 0 0"/> -->
+                <body name="end_link">
+                    <geom name="EE" type="capsule" fromto="0 0 0.3  0.0 0 0.1" size="0.02"/>
+                    <joint name="joint2" type="hinge" pos="0.0 0 0.3" axis="0 1 0"/>
+                </body>
+            </body>
+        </body>
+        <body name="body_ball" pos="1 0 0.06" >
+            <freejoint name="ball_freejoint"/>
+            <geom name="ball" type="sphere" size="0.05" rgba="1.0 0.55 0.0 0.2" mass="0.1"/>
+        </body>
+        <body name="immovable" pos="0.56428 0.221972 0.6">
+            <geom name="box" type="box" size=".0125 .016 .032" rgba=".5 .5 .5 1" />
+            <inertial pos="0 0 0" mass="0.1024" diaginertia="4.369e-5 4.028e-5 1.407e-5"/>
+            <joint name="joint_eq_element1" type="hinge" pos="0 0 0.6" axis="0 1 0"/>
+        </body>
+
+        <camera name="test_cam" pos="0.034 1.833 1.746" xyaxes="-1.000 -0.000 -0.000 0.000 -0.628 0.779"/>
+
+    </worldbody>
+
+</mujoco>

--- a/mujoco_ros/test/launch/mujoco_render.test
+++ b/mujoco_ros/test/launch/mujoco_render.test
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<launch>
+
+  <env name="ROSCONSOLE_FORMAT" value="[${severity}] [${time}] [${logger}] [${node}]: ${message}"/>
+  <env name="ROSCONSOLE_CONFIG_FILE"
+       value="$(find mujoco_ros)/config/rosconsole.config"/>
+
+  <param name="/use_sim_time" value="true"/>
+  <test test-name="mujoco_render_test" pkg="mujoco_ros" type="mujoco_render_test" />
+</launch>

--- a/mujoco_ros/test/launch/mujoco_render.test
+++ b/mujoco_ros/test/launch/mujoco_render.test
@@ -6,5 +6,5 @@
        value="$(find mujoco_ros)/config/rosconsole.config"/>
 
   <param name="/use_sim_time" value="true"/>
-  <test test-name="mujoco_render_test" pkg="mujoco_ros" type="mujoco_render_test" />
+  <test test-name="mujoco_render_test" pkg="mujoco_ros" type="mujoco_render_test" time-limit="120.0"/>
 </launch>

--- a/mujoco_ros/test/mujoco_env_fixture.h
+++ b/mujoco_ros/test/mujoco_env_fixture.h
@@ -63,6 +63,8 @@ public:
 	int isEventRunning() { return is_event_running_; }
 	int isRenderingRunning() { return is_rendering_running_; }
 
+	OffscreenRenderContext *getOffscreenContext() { return &offscreen_; }
+
 	int getNumCBReadyPlugins() { return cb_ready_plugins_.size(); }
 	void notifyGeomChange() { notifyGeomChanged(0); }
 

--- a/mujoco_ros/test/mujoco_env_fixture.h
+++ b/mujoco_ros/test/mujoco_env_fixture.h
@@ -106,7 +106,7 @@ class BaseEnvFixture : public ::testing::Test
 {
 protected:
 	std::unique_ptr<ros::NodeHandle> nh;
-	std::unique_ptr<MujocoEnvTestWrapper> env_ptr;
+	std::unique_ptr<MujocoEnvTestWrapper> env_ptr = nullptr;
 
 	void SetUp() override
 	{

--- a/mujoco_ros/test/mujoco_env_fixture.h
+++ b/mujoco_ros/test/mujoco_env_fixture.h
@@ -99,7 +99,7 @@ protected:
 	{
 		nh = std::make_unique<ros::NodeHandle>("~");
 		nh->setParam("unpause", true);
-		nh->setParam("no_x", true);
+		nh->setParam("no_render", true);
 		nh->setParam("use_sim_time", true);
 	}
 
@@ -120,7 +120,7 @@ protected:
 	{
 		nh = std::make_unique<ros::NodeHandle>("~");
 		nh->setParam("unpause", false);
-		nh->setParam("no_x", true);
+		nh->setParam("no_render", true);
 		nh->setParam("use_sim_time", true);
 		nh->setParam("sim_steps", -1);
 
@@ -162,7 +162,7 @@ protected:
 	{
 		nh.reset(new ros::NodeHandle("~"));
 		nh->setParam("unpause", false);
-		nh->setParam("no_x", true);
+		nh->setParam("no_render", true);
 		nh->setParam("use_sim_time", true);
 		nh->setParam("sim_steps", -1);
 

--- a/mujoco_ros/test/mujoco_env_fixture.h
+++ b/mujoco_ros/test/mujoco_env_fixture.h
@@ -103,7 +103,11 @@ protected:
 		nh->setParam("use_sim_time", true);
 	}
 
-	void TearDown() override {}
+	void TearDown() override
+	{
+		// clean up all parameters
+		ros::param::del(nh->getNamespace());
+	}
 };
 
 class PendulumEnvFixture : public ::testing::Test

--- a/mujoco_ros/test/mujoco_env_test.cpp
+++ b/mujoco_ros/test/mujoco_env_test.cpp
@@ -67,335 +67,250 @@ TEST_F(BaseEnvFixture, RunEvalMode)
 {
 	nh->setParam("eval_mode", true);
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	MujocoEnvTestWrapper env("some_hash");
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("some_hash");
 
-	env.startWithXML(xml_path);
+	env_ptr->startWithXML(xml_path);
 
-	float seconds = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) { // wait for model to be loaded or timeout
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
-	}
-	EXPECT_EQ(env.getFilename(), xml_path) << "Model was not loaded correctly!";
-	EXPECT_FALSE(env.settings_.exit_request) << "Exit request is set before shutdown!";
+	EXPECT_EQ(env_ptr->getFilename(), xml_path) << "Model was not loaded correctly!";
+	EXPECT_FALSE(env_ptr->settings_.exit_request) << "Exit request is set before shutdown!";
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, EvalPauseWithHash)
 {
 	nh->setParam("eval_mode", true);
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	MujocoEnvTestWrapper env("some_hash");
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("some_hash");
 
-	env.startWithXML(xml_path);
-	env.settings_.run = 1;
+	env_ptr->startWithXML(xml_path);
 
-	float seconds = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) { // wait for model to be loaded or timeout
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
-	}
-	EXPECT_EQ(env.getFilename(), xml_path) << "Model was not loaded correctly!";
+	EXPECT_EQ(env_ptr->getFilename(), xml_path) << "Model was not loaded correctly!";
 
-	env.togglePaused(true, "some_hash");
-	EXPECT_FALSE(env.settings_.run) << "Model should not be running!";
+	env_ptr->togglePaused(true, "some_hash");
+	EXPECT_FALSE(env_ptr->settings_.run) << "Model should not be running!";
 
-	env.shutdown();
-}
-
-TEST_F(BaseEnvFixture, EvalPauseWithoutHashForbidden)
-{
-	nh->setParam("eval_mode", true);
-	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	MujocoEnvTestWrapper env("some_hash");
-
-	env.startWithXML(xml_path);
-	env.settings_.run = 1;
-
-	float seconds = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) { // wait for model to be loaded or timeout
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
-	}
-	EXPECT_EQ(env.getFilename(), xml_path) << "Model was not loaded correctly!";
-
-	env.togglePaused(true);
-	EXPECT_TRUE(env.settings_.run) << "Model should still be running!";
-
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, EvalUnpauseWithHash)
 {
 	nh->setParam("eval_mode", true);
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	MujocoEnvTestWrapper env("some_hash");
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("some_hash");
 
-	env.startWithXML(xml_path);
+	env_ptr->startWithXML(xml_path);
 
-	float seconds = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) { // wait for model to be loaded or timeout
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
-	}
-	EXPECT_EQ(env.getFilename(), xml_path) << "Model was not loaded correctly!";
+	EXPECT_EQ(env_ptr->getFilename(), xml_path) << "Model was not loaded correctly!";
 
-	env.togglePaused(false, "some_hash");
-	EXPECT_TRUE(env.settings_.run) << "Model should be running!";
+	env_ptr->togglePaused(false, "some_hash");
+	EXPECT_TRUE(env_ptr->settings_.run) << "Model should be running!";
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, StepBeforeLoad)
 {
-	MujocoEnvTestWrapper env;
-	EXPECT_FALSE(env.step(1));
+	env_ptr = std::make_unique<MujocoEnvTestWrapper>("");
+	EXPECT_FALSE(env_ptr->step(1));
 }
 
 TEST_F(BaseEnvFixture, StepAfterShutdown)
 {
-	MujocoEnvTestWrapper env;
-	env.shutdown();
-	EXPECT_FALSE(env.step(1));
+	env_ptr = std::make_unique<MujocoEnvTestWrapper>("");
+	env_ptr->shutdown();
+	EXPECT_FALSE(env_ptr->step(1));
 }
 
 TEST_F(BaseEnvFixture, StepWhileUnpaused)
 {
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	MujocoEnvTestWrapper env;
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
 
-	env.startWithXML(xml_path);
-	float seconds = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) { // wait for model to be loaded
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
-	}
-	EXPECT_LT(seconds, 2) << "Model was not loaded correctly!";
-	EXPECT_FALSE(env.step(1));
+	env_ptr->startWithXML(xml_path);
+	EXPECT_FALSE(env_ptr->step(1));
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, StepSingleWhilePaused)
 {
 	nh->setParam("unpause", false);
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	MujocoEnvTestWrapper env;
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
 
-	env.startWithXML(xml_path);
-	float seconds = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) { // wait for model to be loaded
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
-	}
-	EXPECT_LT(seconds, 2) << "Model was not loaded correctly!";
-	EXPECT_DOUBLE_EQ(env.getDataPtr()->time, 0.0);
-	EXPECT_TRUE(env.step(1));
-	EXPECT_DOUBLE_EQ(env.getDataPtr()->time, env.getModelPtr()->opt.timestep);
+	env_ptr->startWithXML(xml_path);
+	EXPECT_DOUBLE_EQ(env_ptr->getDataPtr()->time, 0.0);
+	EXPECT_TRUE(env_ptr->step(1));
+	EXPECT_DOUBLE_EQ(env_ptr->getDataPtr()->time, env_ptr->getModelPtr()->opt.timestep);
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, StepMultiWhilePaused)
 {
 	nh->setParam("unpause", false);
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	MujocoEnvTestWrapper env;
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
 
-	env.startWithXML(xml_path);
-	float seconds = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) { // wait for model to be loaded
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
-	}
-	EXPECT_LT(seconds, 2) << "Model was not loaded correctly!";
-	EXPECT_DOUBLE_EQ(env.getDataPtr()->time, 0.0);
-	EXPECT_TRUE(env.step(100));
-	EXPECT_NEAR(env.getDataPtr()->time, 100 * env.getModelPtr()->opt.timestep, 1e-6);
+	env_ptr->startWithXML(xml_path);
+	EXPECT_DOUBLE_EQ(env_ptr->getDataPtr()->time, 0.0);
+	EXPECT_TRUE(env_ptr->step(100));
+	EXPECT_NEAR(env_ptr->getDataPtr()->time, 100 * env_ptr->getModelPtr()->opt.timestep, 1e-6);
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, StepUnblocked)
 {
 	nh->setParam("unpause", false);
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	MujocoEnvTestWrapper env;
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
 
-	env.startWithXML(xml_path);
+	env_ptr->startWithXML(xml_path);
+	EXPECT_DOUBLE_EQ(env_ptr->getDataPtr()->time, 0.0);
+	EXPECT_TRUE(env_ptr->step(100, false));
+	EXPECT_GT(env_ptr->settings_.env_steps_request, 0);
+
 	float seconds = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) { // wait for model to be loaded
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
-	}
-	EXPECT_LT(seconds, 2) << "Model was not loaded correctly!";
-	EXPECT_DOUBLE_EQ(env.getDataPtr()->time, 0.0);
-	EXPECT_TRUE(env.step(100, false));
-	EXPECT_GT(env.settings_.env_steps_request, 0);
-
-	seconds = 0;
-	while (env.getDataPtr()->time < 100 * env.getModelPtr()->opt.timestep && seconds < 2) {
+	while (env_ptr->getDataPtr()->time < 100 * env_ptr->getModelPtr()->opt.timestep && seconds < 2) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
 		seconds += 0.001;
 	}
 	EXPECT_LT(seconds, 2) << "Time should have passed but ran into 2 seconds timeout!";
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, StepNegativeFail)
 {
 	nh->setParam("unpause", false);
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	MujocoEnvTestWrapper env;
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
 
-	env.startWithXML(xml_path);
-	float seconds = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) { // wait for model to be loaded
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
-	}
-	EXPECT_LT(seconds, 2) << "Model was not loaded correctly!";
-	EXPECT_DOUBLE_EQ(env.getDataPtr()->time, 0.0);
-	EXPECT_FALSE(env.step(-10)) << "Stepping with negative steps should not succeed!";
-	EXPECT_EQ(env.settings_.env_steps_request, 0);
-	EXPECT_DOUBLE_EQ(env.getDataPtr()->time, 0.0);
+	env_ptr->startWithXML(xml_path);
+	EXPECT_DOUBLE_EQ(env_ptr->getDataPtr()->time, 0.0);
+	EXPECT_FALSE(env_ptr->step(-10)) << "Stepping with negative steps should not succeed!";
+	EXPECT_EQ(env_ptr->settings_.env_steps_request, 0);
+	EXPECT_DOUBLE_EQ(env_ptr->getDataPtr()->time, 0.0);
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, Shutdown)
 {
-	MujocoEnvTestWrapper env;
+	env_ptr = std::make_unique<MujocoEnvTestWrapper>("");
 
-	EXPECT_FALSE(env.isPhysicsRunning()) << "Physics thread should not be running yet!";
-	EXPECT_FALSE(env.isEventRunning()) << "Event thread should not be running yet!";
+	EXPECT_FALSE(env_ptr->isPhysicsRunning()) << "Physics thread should not be running yet!";
+	EXPECT_FALSE(env_ptr->isEventRunning()) << "Event thread should not be running yet!";
 
-	env.startPhysicsLoop();
-	env.startEventLoop();
+	env_ptr->startPhysicsLoop();
+	env_ptr->startEventLoop();
 
-	EXPECT_FALSE(env.settings_.exit_request) << "Exit request is set before shutdown!";
+	EXPECT_FALSE(env_ptr->settings_.exit_request) << "Exit request is set before shutdown!";
 
 	// Make sure the threads are running
 	float seconds = 0;
-	while (seconds < 2 && (!env.isPhysicsRunning() || !env.isEventRunning())) { // wait for threads to start
+	while (seconds < 2 && (!env_ptr->isPhysicsRunning() || !env_ptr->isEventRunning())) { // wait for threads to start
 		std::this_thread::sleep_for(std::chrono::milliseconds(3));
 		seconds += 0.003;
 	}
-	EXPECT_TRUE(env.isPhysicsRunning()) << "Physics thread should have started by now!";
-	EXPECT_TRUE(env.isEventRunning()) << "Event thread should have started by now!";
+	EXPECT_TRUE(env_ptr->isPhysicsRunning()) << "Physics thread should have started by now!";
+	EXPECT_TRUE(env_ptr->isEventRunning()) << "Event thread should have started by now!";
 
-	env.settings_.exit_request = 1;
+	env_ptr->settings_.exit_request = 1;
 
 	seconds = 0;
-	while (seconds < 2 && (env.isPhysicsRunning() || env.isEventRunning())) { // wait for threads to exit
+	while (seconds < 2 && (env_ptr->isPhysicsRunning() || env_ptr->isEventRunning())) { // wait for threads to exit
 		std::this_thread::sleep_for(std::chrono::milliseconds(3));
 		seconds += 0.003;
 	}
-	EXPECT_FALSE(env.isPhysicsRunning()) << "Physics thread is still running after shutdown!";
-	EXPECT_FALSE(env.isEventRunning()) << "Event thread is still running after shutdown!";
+	EXPECT_FALSE(env_ptr->isPhysicsRunning()) << "Physics thread is still running after shutdown!";
+	EXPECT_FALSE(env_ptr->isEventRunning()) << "Event thread is still running after shutdown!";
 
-	env.waitForEventsJoin();
-	env.waitForPhysicsJoin();
+	env_ptr->waitForEventsJoin();
+	env_ptr->waitForPhysicsJoin();
 }
 
 TEST_F(BaseEnvFixture, InitWithModel)
 {
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/pendulum_world.xml";
-	MujocoEnvTestWrapper env;
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
 
-	env.startWithXML(xml_path);
+	env_ptr->startWithXML(xml_path);
 
 	float seconds = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) { // wait for model to be loaded or timeout
+	while (env_ptr->getOperationalStatus() != 0 && seconds < 2) { // wait for model to be loaded or timeout
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
 		seconds += 0.001;
 	}
-	EXPECT_EQ(env.getFilename(), xml_path) << "Model was not loaded correctly!";
+	EXPECT_EQ(env_ptr->getFilename(), xml_path) << "Model was not loaded correctly!";
 
 	seconds = 0;
-	while (env.getDataPtr()->time == 0 && seconds < 2) { // wait for model to be loaded or timeout
+	while (env_ptr->getDataPtr()->time == 0 && seconds < 2) { // wait for model to be loaded or timeout
 		std::this_thread::sleep_for(std::chrono::milliseconds(5));
 		seconds += 0.005;
 	}
 	EXPECT_LT(seconds, 2) << "Time did not pass in simulation, ran into 2 second timeout!";
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, EvalUnpauseWithoutHash)
 {
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	MujocoEnvTestWrapper env("some_hash");
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("some_hash");
 
-	env.startWithXML(xml_path);
+	env_ptr->startWithXML(xml_path);
 
-	float seconds = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) { // wait for model to be loaded or timeout
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
-	}
-	EXPECT_EQ(env.getFilename(), xml_path) << "Model was not loaded correctly!";
+	EXPECT_EQ(env_ptr->getFilename(), xml_path) << "Model was not loaded correctly!";
 
-	env.togglePaused(false);
-	EXPECT_TRUE(env.settings_.run) << "Model should be running!";
+	env_ptr->togglePaused(false);
+	EXPECT_TRUE(env_ptr->settings_.run) << "Model should be running!";
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, PauseUnpause)
 {
 	nh->setParam("unpause", false);
-	MujocoEnvTestWrapper env;
+	env_ptr = std::make_unique<MujocoEnvTestWrapper>("");
 
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	env.startWithXML(xml_path);
+	env_ptr->startWithXML(xml_path);
 
-	float seconds = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) { // wait for model to be loaded or timeout
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
-	}
+	EXPECT_FALSE(env_ptr->settings_.run) << "Model should not be running!";
 
-	EXPECT_FALSE(env.settings_.run) << "Model should not be running!";
-
-	mjtNum time = env.getDataPtr()->time;
+	mjtNum time = env_ptr->getDataPtr()->time;
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(10));
-	EXPECT_EQ(env.getDataPtr()->time, time) << "Time should not have changed in paused mode!";
+	EXPECT_EQ(env_ptr->getDataPtr()->time, time) << "Time should not have changed in paused mode!";
 
-	env.settings_.run.store(1);
+	env_ptr->settings_.run.store(1);
 
-	seconds = 0;
-	while (env.getDataPtr()->time == time && seconds < 2) { // wait for model to be loaded or timeout
+	float seconds = 0;
+	while (env_ptr->getDataPtr()->time == time && seconds < 2) { // wait for model to be loaded or timeout
 		std::this_thread::sleep_for(std::chrono::milliseconds(5));
 		seconds += 0.005;
 	}
 	EXPECT_LT(seconds, 2) << "Time should have been moving forward in unpaused state, ran into 2 seconds timeout!";
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, StepsTerminate)
 {
 	nh->setParam("num_steps", 100);
 
-	MujocoEnvTestWrapper env;
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/pendulum_world.xml";
-	env.startWithXML(xml_path);
+	env_ptr->startWithXML(xml_path);
 
 	float seconds = 0;
-	while (env.getOperationalStatus() > 1 && seconds < 2) { // wait for model to be loaded or timeout
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
-	}
-
-	seconds = 0;
 	int current;
-	int last = env.getPendingSteps();
-	while (env.getPendingSteps() > 0) {
-		current = env.getPendingSteps();
+	int last = env_ptr->getPendingSteps();
+	while (env_ptr->getPendingSteps() > 0) {
+		current = env_ptr->getPendingSteps();
 		if (current == last) { // wait for model to be loaded or timeout
 			std::this_thread::sleep_for(std::chrono::milliseconds(2));
 			seconds += 0.002;
@@ -408,112 +323,108 @@ TEST_F(BaseEnvFixture, StepsTerminate)
 	}
 	EXPECT_LT(seconds, 2) << "Pending steps should have decreased but ran into 2 seconds timeout";
 
-	EXPECT_NEAR(env.getDataPtr()->time, env.getModelPtr()->opt.timestep * 100, env.getModelPtr()->opt.timestep * 0.1)
+	EXPECT_NEAR(env_ptr->getDataPtr()->time, env_ptr->getModelPtr()->opt.timestep * 100,
+	            env_ptr->getModelPtr()->opt.timestep * 0.1)
 	    << "Time should have stopped after 100 steps";
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, ManualSteps)
 {
 	nh->setParam("unpause", false);
 
-	MujocoEnvTestWrapper env;
+	env_ptr = std::make_unique<MujocoEnvTestWrapper>("");
 
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/pendulum_world.xml";
-	env.startWithXML(xml_path);
+	env_ptr->startWithXML(xml_path);
 
-	while (env.getOperationalStatus() != 0) { // wait for model to be loaded
-		std::this_thread::sleep_for(std::chrono::milliseconds(3));
-	}
+	EXPECT_FALSE(env_ptr->settings_.env_steps_request) << "pending manual steps should be 0 after initialization!";
+	EXPECT_FALSE(env_ptr->settings_.run) << "Model should not be running!";
+	EXPECT_EQ(env_ptr->getDataPtr()->time, 0) << "Time should be 0 after initialization!";
 
-	EXPECT_FALSE(env.settings_.env_steps_request) << "pending manual steps should be 0 after initialization!";
-	EXPECT_FALSE(env.settings_.run) << "Model should not be running!";
-	EXPECT_EQ(env.getDataPtr()->time, 0) << "Time should be 0 after initialization!";
-
-	env.settings_.env_steps_request.store(1);
+	env_ptr->settings_.env_steps_request.store(1);
 
 	float seconds = 0;
-	while (env.settings_.env_steps_request != 0 && seconds < 1) { // wait for model to be loaded
+	while (env_ptr->settings_.env_steps_request != 0 && seconds < 1) { // wait for model to be loaded
 		std::this_thread::sleep_for(std::chrono::milliseconds(2));
 		seconds += 0.002;
 	}
 	EXPECT_LT(seconds, 1) << "Manual step should have been executed but ran into 1 second timeout!";
-	EXPECT_EQ(env.getDataPtr()->time, env.getModelPtr()->opt.timestep) << "Time should have been increased by one step!";
+	EXPECT_EQ(env_ptr->getDataPtr()->time, env_ptr->getModelPtr()->opt.timestep)
+	    << "Time should have been increased by one step!";
 
-	env.settings_.run.store(1);
-	env.settings_.env_steps_request.store(100);
+	env_ptr->settings_.run.store(1);
+	env_ptr->settings_.env_steps_request.store(100);
 
 	// Wait for time to pass
 	std::this_thread::sleep_for(std::chrono::milliseconds(2));
 
-	EXPECT_EQ(env.settings_.env_steps_request, 100) << "pending manual steps should not change in unpaused mode!";
-	env.settings_.env_steps_request.store(0);
-	env.settings_.run.store(0);
+	EXPECT_EQ(env_ptr->settings_.env_steps_request, 100) << "pending manual steps should not change in unpaused mode!";
+	env_ptr->settings_.env_steps_request.store(0);
+	env_ptr->settings_.run.store(0);
 
-	mjtNum time = env.getDataPtr()->time;
+	mjtNum time = env_ptr->getDataPtr()->time;
 
-	env.settings_.env_steps_request.store(100);
+	env_ptr->settings_.env_steps_request.store(100);
 
 	seconds = 0;
-	while (env.settings_.env_steps_request != 0 && seconds < 2) { // wait for model to be loaded
+	while (env_ptr->settings_.env_steps_request != 0 && seconds < 2) { // wait for model to be loaded
 		std::this_thread::sleep_for(std::chrono::milliseconds(5));
 		seconds += 0.005;
 	}
 	EXPECT_LT(seconds, 2) << "Manual step should have been executed but ran into 1 second timeout!";
-	EXPECT_NEAR(env.getDataPtr()->time, time + 100 * env.getModelPtr()->opt.timestep,
-	            env.getModelPtr()->opt.timestep * 0.1)
+	EXPECT_NEAR(env_ptr->getDataPtr()->time, time + 100 * env_ptr->getModelPtr()->opt.timestep,
+	            env_ptr->getModelPtr()->opt.timestep * 0.1)
 	    << "Time should have been increased by 100*timestep!";
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, Reset)
 {
 	nh->setParam("unpause", false);
-	MujocoEnvTestWrapper env;
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/pendulum_world.xml";
-	env.startWithXML(xml_path);
-	while (env.getOperationalStatus() != 0) { // wait for model to be loaded
-		std::this_thread::sleep_for(std::chrono::milliseconds(3));
-	}
+	env_ptr->startWithXML(xml_path);
 
-	EXPECT_TRUE(env.step(100)) << "Stepping failed!";
+	EXPECT_TRUE(env_ptr->step(100)) << "Stepping failed!";
 
-	env.settings_.run = 0;
-	EXPECT_NEAR(env.getDataPtr()->time, 100 * env.getModelPtr()->opt.timestep, 1e-6) << "Time should have been running!";
+	env_ptr->settings_.run = 0;
+	EXPECT_NEAR(env_ptr->getDataPtr()->time, 100 * env_ptr->getModelPtr()->opt.timestep, 1e-6)
+	    << "Time should have been running!";
 
-	env.settings_.reset_request.store(1);
+	env_ptr->settings_.reset_request.store(1);
 
 	float seconds = 0;
-	while (env.settings_.reset_request != 0 && seconds < 2) { // wait for model to be loaded
+	while (env_ptr->settings_.reset_request != 0 && seconds < 2) { // wait for model to be loaded
 		std::this_thread::sleep_for(std::chrono::milliseconds(2));
 		seconds += 0.002;
 	}
 	EXPECT_LT(seconds, 2) << "Reset should have been executed but ran into 2 seconds timeout!";
-	EXPECT_FALSE(env.settings_.run) << "Model should stay paused after reset!";
-	EXPECT_NEAR(env.getDataPtr()->time, 0, 1e-6) << "Time should have been reset to 0!";
+	EXPECT_FALSE(env_ptr->settings_.run) << "Model should stay paused after reset!";
+	EXPECT_NEAR(env_ptr->getDataPtr()->time, 0, 1e-6) << "Time should have been reset to 0!";
 
-	env.settings_.run = 1;
-	env.settings_.reset_request.store(1);
-	while (env.settings_.reset_request != 0) { // wait for model to be loaded
+	env_ptr->settings_.run = 1;
+	env_ptr->settings_.reset_request.store(1);
+	while (env_ptr->settings_.reset_request != 0) { // wait for model to be loaded
 		std::this_thread::sleep_for(std::chrono::milliseconds(2));
 	}
-	EXPECT_TRUE(env.settings_.run) << "Model should keep running after reset!";
+	EXPECT_TRUE(env_ptr->settings_.run) << "Model should keep running after reset!";
 
-	env.settings_.run = 0;
-	int id2           = mujoco_ros::util::jointName2id(env.getModelPtr(), "joint2");
+	env_ptr->settings_.run = 0;
+	int id2                = mujoco_ros::util::jointName2id(env_ptr->getModelPtr(), "joint2");
 	EXPECT_NE(id2, -1) << "joint2 should exist in model!";
-	env.getDataPtr()->qpos[env.getModelPtr()->jnt_qposadr[id2]] = 0.5;
-	env.getDataPtr()->qvel[env.getModelPtr()->jnt_dofadr[id2]]  = 0.1;
-	env.settings_.reset_request.store(1);
-	while (env.settings_.reset_request != 0) { // wait for model to be loaded
+	env_ptr->getDataPtr()->qpos[env_ptr->getModelPtr()->jnt_qposadr[id2]] = 0.5;
+	env_ptr->getDataPtr()->qvel[env_ptr->getModelPtr()->jnt_dofadr[id2]]  = 0.1;
+	env_ptr->settings_.reset_request.store(1);
+	while (env_ptr->settings_.reset_request != 0) { // wait for model to be loaded
 		std::this_thread::sleep_for(std::chrono::milliseconds(2));
 	}
-	EXPECT_NE(env.getDataPtr()->qpos[id2], 0.5) << "joint2 position should have been reset!";
-	EXPECT_NE(env.getDataPtr()->qvel[id2], 0.1) << "joint2 velocity should have been reset!";
+	EXPECT_NE(env_ptr->getDataPtr()->qpos[id2], 0.5) << "joint2 position should have been reset!";
+	EXPECT_NE(env_ptr->getDataPtr()->qvel[id2], 0.1) << "joint2 velocity should have been reset!";
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 // Test reloading
@@ -521,98 +432,86 @@ TEST_F(BaseEnvFixture, Reload)
 {
 	nh->setParam("unpause", false);
 
-	MujocoEnvTestWrapper env;
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	env.startWithXML(xml_path);
-
-	while (env.getOperationalStatus() != 0) { // wait for model to be loaded
-		std::this_thread::sleep_for(std::chrono::milliseconds(3));
-	}
+	env_ptr->startWithXML(xml_path);
 
 	// Load same model again in unpaused state
-	load_queued_model(env);
-	EXPECT_FALSE(env.settings_.run) << "Model should stay paused on init!";
-	EXPECT_EQ(env.getFilename(), xml_path) << "Wrong content in filename_!";
-	EXPECT_EQ(env.getDataPtr()->time, 0) << "Time should have been reset to 0!";
-	EXPECT_EQ(env.settings_.run, 0) << "Model should stay paused after reset!";
+	load_queued_model(env_ptr.get());
+	EXPECT_FALSE(env_ptr->settings_.run) << "Model should stay paused on init!";
+	EXPECT_EQ(env_ptr->getFilename(), xml_path) << "Wrong content in filename_!";
+	EXPECT_EQ(env_ptr->getDataPtr()->time, 0) << "Time should have been reset to 0!";
+	EXPECT_EQ(env_ptr->settings_.run, 0) << "Model should stay paused after reset!";
 
 	// Load new model in paused state
 	std::string xml_path2 = ros::package::getPath("mujoco_ros") + "/test/pendulum_world.xml";
-	mju::strcpy_arr(env.queued_filename_, xml_path2.c_str());
+	mju::strcpy_arr(env_ptr->queued_filename_, xml_path2.c_str());
 
-	load_queued_model(env);
-	EXPECT_EQ(env.getFilename(), xml_path2) << "Wrong content in filename_!";
+	load_queued_model(env_ptr.get());
+	EXPECT_EQ(env_ptr->getFilename(), xml_path2) << "Wrong content in filename_!";
 
-	env.settings_.run.store(1);
+	env_ptr->settings_.run.store(1);
 
 	// Let some time pass
-	while (env.getDataPtr()->time < 0.01) {
+	while (env_ptr->getDataPtr()->time < 0.01) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
 	}
 
 	// Load same model in unpaused state
-	load_queued_model(env);
-	EXPECT_EQ(env.getFilename(), xml_path2) << "Wrong content in filename_!";
+	load_queued_model(env_ptr.get());
+	EXPECT_EQ(env_ptr->getFilename(), xml_path2) << "Wrong content in filename_!";
 
 	// Let some time pass
-	while (env.getDataPtr()->time < 0.01) {
+	while (env_ptr->getDataPtr()->time < 0.01) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
 	}
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, InitModelFromQueuedBuffer)
 {
 	// Create a MujocoEnv object
-	MujocoEnvTestWrapper env;
+	env_ptr = std::make_unique<MujocoEnvTestWrapper>("");
 
 	// Set the queued model buffer
 	std::string queuedFilename = "<mujoco/>";
 
 	// Call the initModelFromQueue function
-	env.startWithXML(queuedFilename);
-
-	while (env.getOperationalStatus() != 0) { // wait for model to be loaded
-		std::this_thread::sleep_for(std::chrono::milliseconds(3));
-	}
+	env_ptr->startWithXML(queuedFilename);
 
 	// Check the result
-	ASSERT_TRUE(env.getModelPtr());
-	ASSERT_TRUE(env.getDataPtr());
-	ASSERT_STREQ(env.getFilename().c_str(), queuedFilename.c_str());
-	ASSERT_TRUE(env.sim_state_.model_valid);
+	ASSERT_TRUE(env_ptr->getModelPtr());
+	ASSERT_TRUE(env_ptr->getDataPtr());
+	ASSERT_STREQ(env_ptr->getFilename().c_str(), queuedFilename.c_str());
+	ASSERT_TRUE(env_ptr->sim_state_.model_valid);
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, InitModelFromInvalidQueuedBuffer)
 {
 	// Create a MujocoEnv object
-	MujocoEnvTestWrapper env;
+	env_ptr = std::make_unique<MujocoEnvTestWrapper>("");
 
 	// Set the queued model buffer
 	std::string valid = "<mujoco/>";
 
 	// Call the initModelFromQueue function
-	env.startWithXML(valid);
-
-	while (env.getOperationalStatus() != 0) { // wait for model to be loaded
-		std::this_thread::sleep_for(std::chrono::milliseconds(3));
-	}
+	env_ptr->startWithXML(valid);
 
 	std::string invalid = "<mujoco>";
-	env.load_filename(invalid);
+	env_ptr->load_filename(invalid);
 
-	while (env.getOperationalStatus() != 0) { // wait for model to be loaded
+	while (env_ptr->getOperationalStatus() != 0) { // wait for model to be loaded
 		std::this_thread::sleep_for(std::chrono::milliseconds(3));
 	}
 
 	// Check the result
-	ASSERT_TRUE(env.getModelPtr());
-	ASSERT_TRUE(env.getDataPtr());
-	ASSERT_STREQ(env.getFilename().c_str(), valid.c_str());
-	ASSERT_FALSE(env.sim_state_.model_valid);
+	ASSERT_TRUE(env_ptr->getModelPtr());
+	ASSERT_TRUE(env_ptr->getDataPtr());
+	ASSERT_STREQ(env_ptr->getFilename().c_str(), valid.c_str());
+	ASSERT_FALSE(env_ptr->sim_state_.model_valid);
 
-	env.shutdown();
+	env_ptr->shutdown();
 }

--- a/mujoco_ros/test/mujoco_env_test.cpp
+++ b/mujoco_ros/test/mujoco_env_test.cpp
@@ -61,7 +61,6 @@ TEST_F(BaseEnvFixture, EvalModeWithoutHashThrow)
 	nh->setParam("eval_mode", true);
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
 	EXPECT_THROW(MujocoEnvTestWrapper env, std::runtime_error);
-	nh->setParam("eval_mode", false);
 }
 
 TEST_F(BaseEnvFixture, RunEvalMode)
@@ -81,7 +80,6 @@ TEST_F(BaseEnvFixture, RunEvalMode)
 	EXPECT_FALSE(env.settings_.exit_request) << "Exit request is set before shutdown!";
 
 	env.shutdown();
-	nh->setParam("eval_mode", false);
 }
 
 TEST_F(BaseEnvFixture, EvalPauseWithHash)
@@ -104,7 +102,6 @@ TEST_F(BaseEnvFixture, EvalPauseWithHash)
 	EXPECT_FALSE(env.settings_.run) << "Model should not be running!";
 
 	env.shutdown();
-	nh->setParam("eval_mode", false);
 }
 
 TEST_F(BaseEnvFixture, EvalPauseWithoutHashForbidden)
@@ -127,7 +124,6 @@ TEST_F(BaseEnvFixture, EvalPauseWithoutHashForbidden)
 	EXPECT_TRUE(env.settings_.run) << "Model should still be running!";
 
 	env.shutdown();
-	nh->setParam("eval_mode", false);
 }
 
 TEST_F(BaseEnvFixture, EvalUnpauseWithHash)
@@ -149,7 +145,6 @@ TEST_F(BaseEnvFixture, EvalUnpauseWithHash)
 	EXPECT_TRUE(env.settings_.run) << "Model should be running!";
 
 	env.shutdown();
-	nh->setParam("eval_mode", false);
 }
 
 TEST_F(BaseEnvFixture, StepBeforeLoad)
@@ -200,7 +195,6 @@ TEST_F(BaseEnvFixture, StepSingleWhilePaused)
 	EXPECT_DOUBLE_EQ(env.getDataPtr()->time, env.getModelPtr()->opt.timestep);
 
 	env.shutdown();
-	nh->setParam("unpause", true);
 }
 
 TEST_F(BaseEnvFixture, StepMultiWhilePaused)
@@ -221,7 +215,6 @@ TEST_F(BaseEnvFixture, StepMultiWhilePaused)
 	EXPECT_NEAR(env.getDataPtr()->time, 100 * env.getModelPtr()->opt.timestep, 1e-6);
 
 	env.shutdown();
-	nh->setParam("unpause", true);
 }
 
 TEST_F(BaseEnvFixture, StepUnblocked)
@@ -249,7 +242,6 @@ TEST_F(BaseEnvFixture, StepUnblocked)
 	EXPECT_LT(seconds, 2) << "Time should have passed but ran into 2 seconds timeout!";
 
 	env.shutdown();
-	nh->setParam("unpause", true);
 }
 
 TEST_F(BaseEnvFixture, StepNegativeFail)
@@ -271,7 +263,6 @@ TEST_F(BaseEnvFixture, StepNegativeFail)
 	EXPECT_DOUBLE_EQ(env.getDataPtr()->time, 0.0);
 
 	env.shutdown();
-	nh->setParam("unpause", true);
 }
 
 TEST_F(BaseEnvFixture, Shutdown)
@@ -384,7 +375,6 @@ TEST_F(BaseEnvFixture, PauseUnpause)
 	EXPECT_LT(seconds, 2) << "Time should have been moving forward in unpaused state, ran into 2 seconds timeout!";
 
 	env.shutdown();
-	nh->setParam("unpause", true);
 }
 
 TEST_F(BaseEnvFixture, StepsTerminate)
@@ -420,7 +410,6 @@ TEST_F(BaseEnvFixture, StepsTerminate)
 
 	EXPECT_NEAR(env.getDataPtr()->time, env.getModelPtr()->opt.timestep * 100, env.getModelPtr()->opt.timestep * 0.1)
 	    << "Time should have stopped after 100 steps";
-	nh->deleteParam("num_steps");
 
 	env.shutdown();
 }
@@ -477,7 +466,6 @@ TEST_F(BaseEnvFixture, ManualSteps)
 	    << "Time should have been increased by 100*timestep!";
 
 	env.shutdown();
-	nh->setParam("unpause", true);
 }
 
 TEST_F(BaseEnvFixture, Reset)
@@ -572,7 +560,6 @@ TEST_F(BaseEnvFixture, Reload)
 	}
 
 	env.shutdown();
-	nh->setParam("unpause", false);
 }
 
 TEST_F(BaseEnvFixture, InitModelFromQueuedBuffer)

--- a/mujoco_ros/test/mujoco_env_test.cpp
+++ b/mujoco_ros/test/mujoco_env_test.cpp
@@ -60,7 +60,7 @@ TEST_F(BaseEnvFixture, EvalModeWithoutHashThrow)
 {
 	nh->setParam("eval_mode", true);
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	EXPECT_THROW(MujocoEnvTestWrapper env, std::runtime_error);
+	EXPECT_THROW(env_ptr = std::make_unique<MujocoEnvTestWrapper>(""), std::runtime_error);
 }
 
 TEST_F(BaseEnvFixture, RunEvalMode)

--- a/mujoco_ros/test/mujoco_render_test.cpp
+++ b/mujoco_ros/test/mujoco_render_test.cpp
@@ -76,9 +76,13 @@ using namespace mujoco_ros;
 namespace mju = ::mujoco::sample_util;
 
 std::vector<sensor_msgs::Image> rgb_images;
+std::vector<sensor_msgs::CameraInfo> rgb_infos;
+
 std::vector<sensor_msgs::Image> depth_images;
+// std::vector<sensor_msgs::CameraInfo> depth_infos;
+
 std::vector<sensor_msgs::Image> seg_images;
-std::vector<sensor_msgs::CameraInfo> cam_infos;
+// std::vector<sensor_msgs::CameraInfo> seg_infos;
 
 // callbacks to save an image in a buffer
 void rgb_cb(const sensor_msgs::Image::ConstPtr &msg)
@@ -93,10 +97,18 @@ void seg_cb(const sensor_msgs::Image::ConstPtr &msg)
 {
 	seg_images.emplace_back(*msg);
 }
-void cam_info_cb(const sensor_msgs::CameraInfo::ConstPtr &msg)
+void rgb_info_cb(const sensor_msgs::CameraInfo::ConstPtr &msg)
 {
-	cam_infos.emplace_back(*msg);
+	rgb_infos.emplace_back(*msg);
 }
+// void depth_info_cb(const sensor_msgs::CameraInfo::ConstPtr &msg)
+// {
+// 	depth_infos.emplace_back(*msg);
+// }
+// void seg_info_cb(const sensor_msgs::CameraInfo::ConstPtr &msg)
+// {
+// 	seg_infos.emplace_back(*msg);
+// }
 
 TEST_F(BaseEnvFixture, Not_Headless_Warn)
 {
@@ -148,7 +160,7 @@ TEST_F(BaseEnvFixture, Headless_params_correct)
 	env_ptr->shutdown();
 }
 
-TEST_F(BaseEnvFixture, RGB_Topic_Available)
+TEST_F(BaseEnvFixture, RGB_Topics_Available)
 {
 	nh->setParam("no_render", false);
 	nh->setParam("headless", true);
@@ -170,19 +182,22 @@ TEST_F(BaseEnvFixture, RGB_Topic_Available)
 	ros::master::V_TopicInfo master_topics;
 	ros::master::getTopics(master_topics);
 
-	bool found = false;
+	bool img = false, info = false;
 	for (const auto &t : master_topics) {
-		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/rgb") {
-			found = true;
-			break;
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/rgb/image_raw") {
+			img = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/rgb/camera_info") {
+			info = true;
 		}
+		if (img && info)
+			break;
 	}
-	EXPECT_TRUE(found);
+	EXPECT_TRUE(img && info);
 
 	env_ptr->shutdown();
 }
 
-TEST_F(BaseEnvFixture, DEPTH_Topic_Available)
+TEST_F(BaseEnvFixture, DEPTH_Topics_Available)
 {
 	nh->setParam("no_render", false);
 	nh->setParam("headless", true);
@@ -204,19 +219,22 @@ TEST_F(BaseEnvFixture, DEPTH_Topic_Available)
 	ros::master::V_TopicInfo master_topics;
 	ros::master::getTopics(master_topics);
 
-	bool found = false;
+	bool img = false, info = false;
 	for (const auto &t : master_topics) {
-		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/depth") {
-			found = true;
-			break;
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/depth/image_raw") {
+			img = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/depth/camera_info") {
+			info = true;
 		}
+		if (img && info)
+			break;
 	}
-	EXPECT_TRUE(found);
+	EXPECT_TRUE(img && info);
 
 	env_ptr->shutdown();
 }
 
-TEST_F(BaseEnvFixture, SEGMENTATION_Topic_Available)
+TEST_F(BaseEnvFixture, SEGMENTATION_Topics_Available)
 {
 	nh->setParam("no_render", false);
 	nh->setParam("headless", true);
@@ -238,18 +256,21 @@ TEST_F(BaseEnvFixture, SEGMENTATION_Topic_Available)
 	ros::master::V_TopicInfo master_topics;
 	ros::master::getTopics(master_topics);
 
-	bool found = false;
+	bool img = false, info = false;
 	for (const auto &t : master_topics) {
-		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/segmented") {
-			found = true;
-			break;
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/segmented/image_raw") {
+			img = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/segmented/camera_info") {
+			info = true;
 		}
+		if (img && info)
+			break;
 	}
-	EXPECT_TRUE(found);
+	EXPECT_TRUE(img && info);
 	env_ptr->shutdown();
 }
 
-TEST_F(BaseEnvFixture, RGB_DEPTH_Topic_Available)
+TEST_F(BaseEnvFixture, RGB_DEPTH_Topics_Available)
 {
 	nh->setParam("no_render", false);
 	nh->setParam("headless", true);
@@ -272,21 +293,26 @@ TEST_F(BaseEnvFixture, RGB_DEPTH_Topic_Available)
 	ros::master::getTopics(master_topics);
 
 	bool found_rgb = false, found_depth = false;
+	bool found_rgb_info = false, found_depth_info = false;
 	for (const auto &t : master_topics) {
-		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/rgb") {
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/rgb/image_raw") {
 			found_rgb = true;
-		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/depth") {
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/depth/image_raw") {
 			found_depth = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/rgb/camera_info") {
+			found_rgb_info = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/depth/camera_info") {
+			found_depth_info = true;
 		}
-		if (found_rgb && found_depth)
+		if (found_rgb && found_depth && found_rgb_info && found_depth_info)
 			break;
 	}
-	EXPECT_TRUE(found_rgb && found_depth);
+	EXPECT_TRUE(found_rgb && found_depth && found_rgb_info && found_depth_info);
 
 	env_ptr->shutdown();
 }
 
-TEST_F(BaseEnvFixture, RGB_SEGMENTATION_Topic_Available)
+TEST_F(BaseEnvFixture, RGB_SEGMENTATION_Topics_Available)
 {
 	nh->setParam("no_render", false);
 	nh->setParam("headless", true);
@@ -309,21 +335,26 @@ TEST_F(BaseEnvFixture, RGB_SEGMENTATION_Topic_Available)
 	ros::master::getTopics(master_topics);
 
 	bool found_rgb = false, found_seg = false;
+	bool found_rgb_info = false, found_seg_info = false;
 	for (const auto &t : master_topics) {
-		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/rgb") {
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/rgb/image_raw") {
 			found_rgb = true;
-		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/segmented") {
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/segmented/image_raw") {
 			found_seg = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/rgb/camera_info") {
+			found_rgb_info = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/segmented/camera_info") {
+			found_seg_info = true;
 		}
-		if (found_rgb && found_seg)
+		if (found_rgb && found_seg && found_rgb_info && found_seg_info)
 			break;
 	}
-	EXPECT_TRUE(found_rgb && found_seg);
+	EXPECT_TRUE(found_rgb && found_seg && found_rgb_info && found_seg_info);
 
 	env_ptr->shutdown();
 }
 
-TEST_F(BaseEnvFixture, DEPTH_SEGMENTATION_Topic_Available)
+TEST_F(BaseEnvFixture, DEPTH_SEGMENTATION_Topics_Available)
 {
 	nh->setParam("no_render", false);
 	nh->setParam("headless", true);
@@ -346,20 +377,25 @@ TEST_F(BaseEnvFixture, DEPTH_SEGMENTATION_Topic_Available)
 	ros::master::getTopics(master_topics);
 
 	bool found_depth = false, found_seg = false;
+	bool found_depth_info = false, found_seg_info = false;
 	for (const auto &t : master_topics) {
-		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/depth") {
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/depth/image_raw") {
 			found_depth = true;
-		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/segmented") {
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/segmented/image_raw") {
 			found_seg = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/depth/camera_info") {
+			found_depth_info = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/segmented/camera_info") {
+			found_seg_info = true;
 		}
-		if (found_depth && found_seg)
+		if (found_depth && found_seg && found_depth_info && found_seg_info)
 			break;
 	}
-	EXPECT_TRUE(found_depth && found_seg);
+	EXPECT_TRUE(found_depth && found_seg && found_depth_info && found_seg_info);
 	env_ptr->shutdown();
 }
 
-TEST_F(BaseEnvFixture, RGB_DEPTH_SEGMENTATION_Topic_Available)
+TEST_F(BaseEnvFixture, RGB_DEPTH_SEGMENTATION_Topics_Available)
 {
 	nh->setParam("no_render", false);
 	nh->setParam("headless", true);
@@ -382,19 +418,25 @@ TEST_F(BaseEnvFixture, RGB_DEPTH_SEGMENTATION_Topic_Available)
 	ros::master::getTopics(master_topics);
 
 	bool found_rgb = false, found_depth = false, found_seg = false;
+	bool found_rgb_info = false, found_depth_info = false, found_seg_info = false;
 	for (const auto &t : master_topics) {
-		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/rgb") {
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/rgb/image_raw") {
 			found_rgb = true;
-		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/depth") {
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/depth/image_raw") {
 			found_depth = true;
-		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/segmented") {
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/segmented/image_raw") {
 			found_seg = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/rgb/camera_info") {
+			found_rgb_info = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/depth/camera_info") {
+			found_depth_info = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/segmented/camera_info") {
+			found_seg_info = true;
 		}
-		if (found_rgb && found_depth && found_seg)
+		if (found_rgb && found_depth && found_seg && found_rgb_info && found_depth_info && found_seg_info)
 			break;
 	}
-	EXPECT_TRUE(found_rgb && found_depth && found_seg);
-	env_ptr->shutdown();
+	EXPECT_TRUE(found_rgb && found_depth && found_seg && found_rgb_info && found_depth_info && found_seg_info);
 
 	env_ptr->shutdown();
 }
@@ -454,6 +496,206 @@ TEST_F(BaseEnvFixture, Resolution_Settings)
 	env_ptr->shutdown();
 }
 
+TEST_F(BaseEnvFixture, Stream_BaseTopic_Relative)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("cam_config/test_cam/stream_type", rendering::streamType::RGB_D_S);
+	nh->setParam("cam_config/test_cam/topic", "alt_topic");
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+	EXPECT_EQ(offscreen->cams[0]->cam_id_, 0);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_STREQ(offscreen->cams[0]->topic_.c_str(), "alt_topic");
+
+	bool found_rgb = false, found_depth = false, found_seg = false;
+	bool found_rgb_info = false, found_depth_info = false, found_seg_info = false;
+
+	ros::master::V_TopicInfo master_topics;
+	ros::master::getTopics(master_topics);
+
+	for (const auto &t : master_topics) {
+		if (t.name == env_ptr->getHandleNamespace() + "/alt_topic/rgb/image_raw") {
+			found_rgb = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/alt_topic/depth/image_raw") {
+			found_depth = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/alt_topic/segmented/image_raw") {
+			found_seg = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/alt_topic/rgb/camera_info") {
+			found_rgb_info = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/alt_topic/depth/camera_info") {
+			found_depth_info = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/alt_topic/segmented/camera_info") {
+			found_seg_info = true;
+		}
+		if (found_rgb && found_depth && found_seg && found_rgb_info && found_depth_info && found_seg_info)
+			break;
+	}
+	EXPECT_TRUE(found_rgb && found_depth && found_seg && found_rgb_info && found_depth_info && found_seg_info);
+
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, Stream_BaseTopic_Absolute)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("cam_config/test_cam/stream_type", rendering::streamType::RGB_D_S);
+	nh->setParam("cam_config/test_cam/topic", "/alt_topic");
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+	EXPECT_EQ(offscreen->cams[0]->cam_id_, 0);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_STREQ(offscreen->cams[0]->topic_.c_str(), "/alt_topic");
+
+	bool found_rgb = false, found_depth = false, found_seg = false;
+	bool found_rgb_info = false, found_depth_info = false, found_seg_info = false;
+
+	ros::master::V_TopicInfo master_topics;
+	ros::master::getTopics(master_topics);
+
+	for (const auto &t : master_topics) {
+		if (t.name == "/alt_topic/rgb/image_raw") {
+			found_rgb = true;
+		} else if (t.name == "/alt_topic/depth/image_raw") {
+			found_depth = true;
+		} else if (t.name == "/alt_topic/segmented/image_raw") {
+			found_seg = true;
+		} else if (t.name == "/alt_topic/rgb/camera_info") {
+			found_rgb_info = true;
+		} else if (t.name == "/alt_topic/depth/camera_info") {
+			found_depth_info = true;
+		} else if (t.name == "/alt_topic/segmented/camera_info") {
+			found_seg_info = true;
+		}
+		if (found_rgb && found_depth && found_seg && found_rgb_info && found_depth_info && found_seg_info)
+			break;
+	}
+	EXPECT_TRUE(found_rgb && found_depth && found_seg && found_rgb_info && found_depth_info && found_seg_info);
+
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, RGB_Alternative_StreamName)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("cam_config/test_cam/stream_type", rendering::streamType::RGB);
+	nh->setParam("cam_config/test_cam/name_rgb", "alt_rgb");
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+	EXPECT_EQ(offscreen->cams[0]->cam_id_, 0);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+
+	bool img = false, found_info = false;
+
+	ros::master::V_TopicInfo master_topics;
+	ros::master::getTopics(master_topics);
+
+	for (const auto &t : master_topics) {
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/alt_rgb/image_raw") {
+			img = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/alt_rgb/camera_info") {
+			found_info = true;
+		}
+		if (img && found_info)
+			break;
+	}
+	EXPECT_TRUE(img && found_info);
+
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, DEPTH_Alternative_StreamName)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("cam_config/test_cam/stream_type", rendering::streamType::DEPTH);
+	nh->setParam("cam_config/test_cam/name_depth", "alt_depth");
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+	EXPECT_EQ(offscreen->cams[0]->cam_id_, 0);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+
+	bool img = false, found_info = false;
+
+	ros::master::V_TopicInfo master_topics;
+	ros::master::getTopics(master_topics);
+
+	for (const auto &t : master_topics) {
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/alt_depth/image_raw") {
+			img = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/alt_depth/camera_info") {
+			found_info = true;
+		}
+		if (img && found_info)
+			break;
+	}
+	EXPECT_TRUE(img && found_info);
+
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, SEGMENT_Alternative_StreamName)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("cam_config/test_cam/stream_type", rendering::streamType::SEGMENTED);
+	nh->setParam("cam_config/test_cam/name_segment", "alt_seg");
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+	EXPECT_EQ(offscreen->cams[0]->cam_id_, 0);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+
+	bool img = false, found_info = false;
+
+	ros::master::V_TopicInfo master_topics;
+	ros::master::getTopics(master_topics);
+
+	for (const auto &t : master_topics) {
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/alt_seg/image_raw") {
+			img = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/alt_seg/camera_info") {
+			found_info = true;
+		}
+		if (img && found_info)
+			break;
+	}
+	EXPECT_TRUE(img && found_info);
+
+	env_ptr->shutdown();
+}
+
 TEST_F(BaseEnvFixture, RGB_Published_Correctly)
 {
 	nh->setParam("no_render", false);
@@ -468,51 +710,50 @@ TEST_F(BaseEnvFixture, RGB_Published_Correctly)
 
 	// Clear image buffers
 	rgb_images.clear();
-	cam_infos.clear();
+	rgb_infos.clear();
 
 	// Subscribe to topic
-	ros::Subscriber rgb_sub  = nh->subscribe("cameras/test_cam/rgb", 1, rgb_cb);
-	ros::Subscriber info_sub = nh->subscribe("cameras/test_cam/camera_info", 1, cam_info_cb);
+	ros::Subscriber rgb_sub  = nh->subscribe("cameras/test_cam/rgb/image_raw", 1, rgb_cb);
+	ros::Subscriber info_sub = nh->subscribe("cameras/test_cam/rgb/camera_info", 1, rgb_info_cb);
 
 	env_ptr->startWithXML(xml_path);
+	env_ptr->step(1);
 
 	EXPECT_TRUE(env_ptr->settings_.headless);
 	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
 
 	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
-	ASSERT_EQ(offscreen->cams.size(), 1);
 
-	// Check default camera settings
+	ASSERT_EQ(offscreen->cams.size(), 1);
 	EXPECT_EQ(offscreen->cams[0]->cam_id_, 0);
 	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_EQ(offscreen->cams[0]->rgb_pub_.getNumSubscribers(), 1);
+
+	// Wait for image to be published with 400ms timeout
+	float seconds = 0.f;
+	while (rgb_images.size() == 0 && rgb_infos.size() == 0 && seconds < .4f) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		seconds += 0.001f;
+	}
+	EXPECT_LT(seconds, .4f) << "RGB image not published within 400ms";
+
 	EXPECT_EQ(offscreen->cams[0]->stream_type_, rendering::streamType::RGB);
 	EXPECT_EQ(offscreen->cams[0]->pub_freq_, 30);
-	EXPECT_EQ(offscreen->cams[0]->width_, 72);
-	EXPECT_EQ(offscreen->cams[0]->height_, 48);
 
-	env_ptr->step(1);
-	// Wait for image to be published with 100ms timeout
-	float seconds = 0;
-	while (rgb_images.size() == 0 && seconds < .1) {
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
-	}
-	EXPECT_LT(seconds, .1) << "RGB image not published within 100ms";
-
-	ASSERT_EQ(cam_infos.size(), 1);
+	ASSERT_EQ(rgb_infos.size(), 1);
 	ASSERT_EQ(rgb_images.size(), 1);
 
 	ros::Time t1 = ros::Time::now();
 	EXPECT_EQ(rgb_images[0].header.stamp, t1);
-	EXPECT_EQ(rgb_images[0].header.frame_id, "test_cam_optical_frame");
+	EXPECT_STREQ(rgb_images[0].header.frame_id.c_str(), "test_cam_optical_frame");
 	EXPECT_EQ(rgb_images[0].width, 72);
 	EXPECT_EQ(rgb_images[0].height, 48);
 	EXPECT_EQ(rgb_images[0].encoding, sensor_msgs::image_encodings::RGB8);
 
-	EXPECT_EQ(cam_infos[0].header.stamp, t1);
+	EXPECT_EQ(rgb_infos[0].header.stamp, t1);
 
 	rgb_images.clear();
-	cam_infos.clear();
+	rgb_infos.clear();
 
 	env_ptr->shutdown();
 }
@@ -531,11 +772,11 @@ TEST_F(BaseEnvFixture, Cam_Timing_Correct)
 
 	// Clear image buffers
 	rgb_images.clear();
-	cam_infos.clear();
+	rgb_infos.clear();
 
 	// Subscribe to topic
-	ros::Subscriber rgb_sub  = nh->subscribe("cameras/test_cam/rgb", 1, rgb_cb);
-	ros::Subscriber info_sub = nh->subscribe("cameras/test_cam/camera_info", 1, cam_info_cb);
+	ros::Subscriber rgb_sub  = nh->subscribe("cameras/test_cam/rgb/image_raw", 1, rgb_cb);
+	ros::Subscriber info_sub = nh->subscribe("cameras/test_cam/rgb/camera_info", 1, rgb_info_cb);
 
 	env_ptr->startWithXML(xml_path);
 
@@ -543,13 +784,6 @@ TEST_F(BaseEnvFixture, Cam_Timing_Correct)
 	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
 
 	env_ptr->step(1);
-	// Wait for image to be published with 100ms timeout
-	float seconds = 0;
-	while (rgb_images.size() == 0 && seconds < .1) {
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
-	}
-	EXPECT_LT(seconds, .1) << "RGB image not published within 100ms";
 
 	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
 	ASSERT_EQ(offscreen->cams.size(), 1);
@@ -560,22 +794,20 @@ TEST_F(BaseEnvFixture, Cam_Timing_Correct)
 	EXPECT_EQ(offscreen->cams[0]->stream_type_, rendering::streamType::RGB);
 	EXPECT_EQ(offscreen->cams[0]->pub_freq_, 30);
 
-	// Wait for image to be published with 100ms timeout
-	seconds = 0;
-	while (rgb_images.size() == 0 && seconds < 0.1) {
+	// Wait for image to be published with 400ms timeout
+	float seconds = 0.f;
+	while (rgb_images.size() == 0 && rgb_infos.size() == 0 && seconds < .4f) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
+		seconds += 0.001f;
 	}
-	EXPECT_LT(seconds, 0.1) << "RGB image not published within 100ms";
+	EXPECT_LT(seconds, .4f) << "RGB image not published within 400ms";
 
-	ASSERT_EQ(cam_infos.size(), 1);
+	ASSERT_EQ(rgb_infos.size(), 1);
 	ASSERT_EQ(rgb_images.size(), 1);
 
 	ros::Time t1 = ros::Time::now();
 	// Step the simulation to as to trigger the camera rendering
-	mjModel *m = env_ptr->getModelPtr();
-	ROS_INFO_STREAM("Next pub time will be " << (1.0 / 30.0) << " seconds from now. Thus in "
-	                                         << std::ceil((1.0 / 30.0) / m->opt.timestep) << " steps.");
+	mjModel *m  = env_ptr->getModelPtr();
 	int n_steps = std::ceil((1.0 / 30.0) / env_ptr->getModelPtr()->opt.timestep);
 
 	env_ptr->step(n_steps - 1);
@@ -583,28 +815,28 @@ TEST_F(BaseEnvFixture, Cam_Timing_Correct)
 	std::this_thread::sleep_for(std::chrono::milliseconds(5));
 
 	// should not have received a new image yet
-	ASSERT_EQ(cam_infos.size(), 1);
+	ASSERT_EQ(rgb_infos.size(), 1);
 	ASSERT_EQ(rgb_images.size(), 1);
 
 	env_ptr->step(1);
-	// Wait for image to be published with 100ms timeout
-	seconds = 0;
-	while (rgb_images.size() < 2 && seconds < 0.1) {
+	// Wait for image to be published with 400ms timeout
+	seconds = 0.f;
+	while (rgb_images.size() < 2 && rgb_infos.size() < 2 && seconds < .4f) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
+		seconds += 0.001f;
 	}
 	// should now have received new image
-	EXPECT_LT(seconds, 0.1) << "RGB image not published within 100ms";
+	EXPECT_LT(seconds, .4f) << "RGB image not published within 400ms";
 
-	ASSERT_EQ(cam_infos.size(), 2);
+	ASSERT_EQ(rgb_infos.size(), 2);
 	ASSERT_EQ(rgb_images.size(), 2);
 	ros::Time t2 = ros::Time::now();
 
 	ASSERT_EQ(rgb_images[0].header.stamp, t1);
 	ASSERT_EQ(rgb_images[1].header.stamp, t2);
 
-	ASSERT_EQ(cam_infos[0].header.stamp, t1);
-	ASSERT_EQ(cam_infos[1].header.stamp, t2);
+	ASSERT_EQ(rgb_infos[0].header.stamp, t1);
+	ASSERT_EQ(rgb_infos[1].header.stamp, t2);
 
 	// int n_steps = std::ceil((1.0 / 30.0) / env_ptr->getModelPtr()->opt.timestep);
 	ros::Time t3 = t2 + ros::Duration((std::ceil((1.0 / 30.0) / m->opt.timestep)) * m->opt.timestep);
@@ -612,16 +844,16 @@ TEST_F(BaseEnvFixture, Cam_Timing_Correct)
 	// Step over next image trigger but before trigger after that
 	env_ptr->step(2 * n_steps - 1);
 
-	ASSERT_EQ(cam_infos.size(), 3);
+	ASSERT_EQ(rgb_infos.size(), 3);
 	ASSERT_EQ(rgb_images.size(), 3);
 
 	// Check that the timestamps are as expected
-	EXPECT_EQ(rgb_images[2].header.stamp, cam_infos[2].header.stamp);
+	EXPECT_EQ(rgb_images[2].header.stamp, rgb_infos[2].header.stamp);
 	EXPECT_EQ(rgb_images[2].header.stamp, t3);
-	EXPECT_EQ(cam_infos[2].header.stamp, t3);
+	EXPECT_EQ(rgb_infos[2].header.stamp, t3);
 
 	rgb_images.clear();
-	cam_infos.clear();
+	rgb_infos.clear();
 
 	env_ptr->shutdown();
 }
@@ -641,7 +873,7 @@ TEST_F(BaseEnvFixture, RGB_Image_Dtype)
 	rgb_images.clear();
 
 	// Subscribe to topic
-	ros::Subscriber rgb_sub = nh->subscribe("cameras/test_cam/rgb", 1, rgb_cb);
+	ros::Subscriber rgb_sub = nh->subscribe("cameras/test_cam/rgb/image_raw", 1, rgb_cb);
 
 	env_ptr->startWithXML(xml_path);
 
@@ -657,13 +889,13 @@ TEST_F(BaseEnvFixture, RGB_Image_Dtype)
 	EXPECT_EQ(offscreen->cams[0]->width_, 72);
 	EXPECT_EQ(offscreen->cams[0]->height_, 48);
 
-	// Wait for image to be published with 100ms timeout
-	float seconds = 0;
-	while (rgb_images.size() == 0 && seconds < .1) {
+	// Wait for image to be published with 400ms timeout
+	float seconds = 0.f;
+	while (rgb_images.size() == 0 && seconds < .4f) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
+		seconds += 0.001f;
 	}
-	EXPECT_LT(seconds, .1) << "RGB image not published within 100ms";
+	EXPECT_LT(seconds, .4f) << "RGB image not published within 400ms";
 
 	ASSERT_EQ(rgb_images.size(), 1);
 	EXPECT_EQ(rgb_images[0].data.size(), 72 * 48 * 3);
@@ -690,7 +922,7 @@ TEST_F(BaseEnvFixture, DEPTH_Image_Dtype)
 	depth_images.clear();
 
 	// Subscribe to topic
-	ros::Subscriber depth_sub = nh->subscribe("cameras/test_cam/depth", 1, depth_cb);
+	ros::Subscriber depth_sub = nh->subscribe("cameras/test_cam/depth/image_raw", 1, depth_cb);
 
 	env_ptr->startWithXML(xml_path);
 
@@ -706,13 +938,13 @@ TEST_F(BaseEnvFixture, DEPTH_Image_Dtype)
 	EXPECT_EQ(offscreen->cams[0]->width_, 72);
 	EXPECT_EQ(offscreen->cams[0]->height_, 48);
 
-	// Wait for image to be published with 100ms timeout
-	float seconds = 0;
-	while (depth_images.size() == 0 && seconds < .1) {
+	// Wait for image to be published with 200ms timeout
+	float seconds = 0.f;
+	while (depth_images.size() == 0 && seconds < .2f) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
+		seconds += 0.001f;
 	}
-	EXPECT_LT(seconds, .1) << "Depth image not published within 100ms";
+	EXPECT_LT(seconds, .2f) << "Depth image not published within 200ms";
 
 	ASSERT_EQ(depth_images.size(), 1);
 	EXPECT_EQ(depth_images[0].width, 72);
@@ -739,7 +971,7 @@ TEST_F(BaseEnvFixture, SEGMENTED_Image_Dtype)
 	seg_images.clear();
 
 	// Subscribe to topic
-	ros::Subscriber seg_sub = nh->subscribe("cameras/test_cam/segmented", 1, seg_cb);
+	ros::Subscriber seg_sub = nh->subscribe("cameras/test_cam/segmented/image_raw", 1, seg_cb);
 
 	env_ptr->startWithXML(xml_path);
 
@@ -755,16 +987,17 @@ TEST_F(BaseEnvFixture, SEGMENTED_Image_Dtype)
 	EXPECT_EQ(offscreen->cams[0]->width_, 72);
 	EXPECT_EQ(offscreen->cams[0]->height_, 48);
 
-	// Wait for image to be published with 100ms timeout
-	float seconds = 0;
-	while (seg_images.size() == 0 && seconds < .1) {
+	// Wait for image to be published with 200ms timeout
+	float seconds = 0.f;
+	while (seg_images.size() == 0 && seconds < .2f) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		seconds += 0.001;
+		seconds += 0.001f;
 	}
-	EXPECT_LT(seconds, .1) << "Segmentation image not published within 100ms";
+	EXPECT_LT(seconds, .2f) << "Segmentation image not published within 200ms";
 
 	ASSERT_EQ(seg_images.size(), 1);
-	EXPECT_EQ(seg_images[0].data.size(), 72 * 48 * 1);
+	EXPECT_EQ(seg_images[0].data.size(), 72 * 48 * 3);
+	EXPECT_EQ(seg_images[0].encoding, sensor_msgs::image_encodings::RGB8);
 
 	seg_images.clear();
 	env_ptr->shutdown();

--- a/mujoco_ros/test/mujoco_render_test.cpp
+++ b/mujoco_ros/test/mujoco_render_test.cpp
@@ -1,0 +1,808 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2024, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: David P. Leins */
+
+#include <gtest/gtest.h>
+
+#include "mujoco_env_fixture.h"
+
+#include <mujoco_ros/mujoco_env.h>
+#include <mujoco_ros/common_types.h>
+#include <mujoco_ros/offscreen_camera.h>
+#include <mujoco_ros/util.h>
+
+#include <ros/ros.h>
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/CameraInfo.h>
+#include <sensor_msgs/image_encodings.h>
+#include <vector>
+#include <chrono>
+#include <cmath>
+
+int main(int argc, char **argv)
+{
+	::testing::InitGoogleTest(&argc, argv);
+	ros::init(argc, argv, "mujoco_render_test");
+
+	// Uncomment to enable debug output (useful for debugging failing tests)
+	// ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Debug);
+	// ros::console::notifyLoggerLevelsChanged();
+
+	// Create spinner to communicate with ROS
+	ros::AsyncSpinner spinner(1);
+	spinner.start();
+	ros::NodeHandle nh;
+	int ret = RUN_ALL_TESTS();
+
+	// Stop spinner and shutdown ROS before returning
+	spinner.stop();
+	ros::shutdown();
+	return ret;
+}
+
+using namespace mujoco_ros;
+namespace mju = ::mujoco::sample_util;
+
+std::vector<sensor_msgs::Image> rgb_images;
+std::vector<sensor_msgs::Image> depth_images;
+std::vector<sensor_msgs::Image> seg_images;
+std::vector<sensor_msgs::CameraInfo> cam_infos;
+
+// callbacks to save an image in a buffer
+void rgb_cb(const sensor_msgs::Image::ConstPtr &msg)
+{
+	rgb_images.emplace_back(*msg);
+}
+void depth_cb(const sensor_msgs::Image::ConstPtr &msg)
+{
+	depth_images.emplace_back(*msg);
+}
+void seg_cb(const sensor_msgs::Image::ConstPtr &msg)
+{
+	seg_images.emplace_back(*msg);
+}
+void cam_info_cb(const sensor_msgs::CameraInfo::ConstPtr &msg)
+{
+	cam_infos.emplace_back(*msg);
+}
+
+TEST_F(BaseEnvFixture, Not_Headless_Warn)
+{
+	nh->setParam("no_render", false);
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	while (env_ptr->getOperationalStatus() != 0) { // wait for model to be loaded
+		std::this_thread::sleep_for(std::chrono::milliseconds(3));
+	}
+
+	env_ptr->shutdown();
+}
+
+#if defined(USE_GLFW) || defined(USE_EGL) || defined(USE_OSMESA) // i.e. any render backend available
+TEST_F(BaseEnvFixture, NoRender_Params_Correct)
+{
+	nh->setParam("no_render", true);
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	bool offscreen = true, headless = false;
+	nh->getParam("render_offscreen", offscreen);
+	nh->getParam("headless", headless);
+	EXPECT_TRUE(headless);
+	EXPECT_TRUE(env_ptr->settings_.headless);
+	EXPECT_FALSE(offscreen);
+	EXPECT_FALSE(env_ptr->settings_.render_offscreen);
+
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, Headless_params_correct)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
+	EXPECT_TRUE(env_ptr->settings_.headless);
+
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, RGB_Topic_Available)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("cam_config/test_cam/stream_type", rendering::streamType::RGB);
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	EXPECT_TRUE(env_ptr->settings_.headless);
+	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_TRUE(offscreen->cams[0]->stream_type_ == rendering::streamType::RGB);
+
+	ros::master::V_TopicInfo master_topics;
+	ros::master::getTopics(master_topics);
+
+	bool found = false;
+	for (const auto &t : master_topics) {
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/rgb") {
+			found = true;
+			break;
+		}
+	}
+	EXPECT_TRUE(found);
+
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, DEPTH_Topic_Available)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("cam_config/test_cam/stream_type", rendering::streamType::DEPTH);
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	EXPECT_TRUE(env_ptr->settings_.headless);
+	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_TRUE(offscreen->cams[0]->stream_type_ == rendering::streamType::DEPTH);
+
+	ros::master::V_TopicInfo master_topics;
+	ros::master::getTopics(master_topics);
+
+	bool found = false;
+	for (const auto &t : master_topics) {
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/depth") {
+			found = true;
+			break;
+		}
+	}
+	EXPECT_TRUE(found);
+
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, SEGMENTATION_Topic_Available)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("cam_config/test_cam/stream_type", rendering::streamType::SEGMENTED);
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	EXPECT_TRUE(env_ptr->settings_.headless);
+	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_TRUE(offscreen->cams[0]->stream_type_ == rendering::streamType::SEGMENTED);
+
+	ros::master::V_TopicInfo master_topics;
+	ros::master::getTopics(master_topics);
+
+	bool found = false;
+	for (const auto &t : master_topics) {
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/segmented") {
+			found = true;
+			break;
+		}
+	}
+	EXPECT_TRUE(found);
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, RGB_DEPTH_Topic_Available)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("cam_config/test_cam/stream_type", rendering::streamType::RGB_D);
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	EXPECT_TRUE(env_ptr->settings_.headless);
+	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_TRUE(offscreen->cams[0]->stream_type_ == rendering::streamType::RGB_D);
+
+	ros::master::V_TopicInfo master_topics;
+	ros::master::getTopics(master_topics);
+
+	bool found_rgb = false, found_depth = false;
+	for (const auto &t : master_topics) {
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/rgb") {
+			found_rgb = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/depth") {
+			found_depth = true;
+		}
+		if (found_rgb && found_depth)
+			break;
+	}
+	EXPECT_TRUE(found_rgb && found_depth);
+
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, RGB_SEGMENTATION_Topic_Available)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("cam_config/test_cam/stream_type", rendering::streamType::RGB_S);
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	EXPECT_TRUE(env_ptr->settings_.headless);
+	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_TRUE(offscreen->cams[0]->stream_type_ == rendering::streamType::RGB_S);
+
+	ros::master::V_TopicInfo master_topics;
+	ros::master::getTopics(master_topics);
+
+	bool found_rgb = false, found_seg = false;
+	for (const auto &t : master_topics) {
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/rgb") {
+			found_rgb = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/segmented") {
+			found_seg = true;
+		}
+		if (found_rgb && found_seg)
+			break;
+	}
+	EXPECT_TRUE(found_rgb && found_seg);
+
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, DEPTH_SEGMENTATION_Topic_Available)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("cam_config/test_cam/stream_type", rendering::streamType::DEPTH_S);
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	EXPECT_TRUE(env_ptr->settings_.headless);
+	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_TRUE(offscreen->cams[0]->stream_type_ == rendering::streamType::DEPTH_S);
+
+	ros::master::V_TopicInfo master_topics;
+	ros::master::getTopics(master_topics);
+
+	bool found_depth = false, found_seg = false;
+	for (const auto &t : master_topics) {
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/depth") {
+			found_depth = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/segmented") {
+			found_seg = true;
+		}
+		if (found_depth && found_seg)
+			break;
+	}
+	EXPECT_TRUE(found_depth && found_seg);
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, RGB_DEPTH_SEGMENTATION_Topic_Available)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("cam_config/test_cam/stream_type", rendering::streamType::RGB_D_S);
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	EXPECT_TRUE(env_ptr->settings_.headless);
+	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_TRUE(offscreen->cams[0]->stream_type_ == rendering::streamType::RGB_D_S);
+
+	ros::master::V_TopicInfo master_topics;
+	ros::master::getTopics(master_topics);
+
+	bool found_rgb = false, found_depth = false, found_seg = false;
+	for (const auto &t : master_topics) {
+		if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/rgb") {
+			found_rgb = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/depth") {
+			found_depth = true;
+		} else if (t.name == env_ptr->getHandleNamespace() + "/cameras/test_cam/segmented") {
+			found_seg = true;
+		}
+		if (found_rgb && found_depth && found_seg)
+			break;
+	}
+	EXPECT_TRUE(found_rgb && found_depth && found_seg);
+	env_ptr->shutdown();
+
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, Default_Cam_Settings)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	EXPECT_TRUE(env_ptr->settings_.headless);
+	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+
+	// Check default camera settings
+	EXPECT_EQ(offscreen->cams[0]->cam_id_, 0);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_EQ(offscreen->cams[0]->stream_type_, rendering::streamType::RGB);
+	EXPECT_EQ(offscreen->cams[0]->pub_freq_, 15);
+	EXPECT_EQ(offscreen->cams[0]->width_, 720);
+	EXPECT_EQ(offscreen->cams[0]->height_, 480);
+
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, Resolution_Settings)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("cam_config/test_cam/width", 640);
+	nh->setParam("cam_config/test_cam/height", 480);
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	EXPECT_TRUE(env_ptr->settings_.headless);
+	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+
+	// Check camera settings
+	EXPECT_EQ(offscreen->cams[0]->cam_id_, 0);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_EQ(offscreen->cams[0]->stream_type_, rendering::streamType::RGB);
+	EXPECT_EQ(offscreen->cams[0]->pub_freq_, 15);
+	EXPECT_EQ(offscreen->cams[0]->width_, 640);
+	EXPECT_EQ(offscreen->cams[0]->height_, 480);
+
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, RGB_Published_Correctly)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("unpause", false);
+	nh->setParam("cam_config/test_cam/frequency", 30);
+	nh->setParam("cam_config/test_cam/width", 72);
+	nh->setParam("cam_config/test_cam/height", 48);
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	// Clear image buffers
+	rgb_images.clear();
+	cam_infos.clear();
+
+	// Subscribe to topic
+	ros::Subscriber rgb_sub  = nh->subscribe("cameras/test_cam/rgb", 1, rgb_cb);
+	ros::Subscriber info_sub = nh->subscribe("cameras/test_cam/camera_info", 1, cam_info_cb);
+
+	env_ptr->startWithXML(xml_path);
+
+	EXPECT_TRUE(env_ptr->settings_.headless);
+	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+
+	// Check default camera settings
+	EXPECT_EQ(offscreen->cams[0]->cam_id_, 0);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_EQ(offscreen->cams[0]->stream_type_, rendering::streamType::RGB);
+	EXPECT_EQ(offscreen->cams[0]->pub_freq_, 30);
+	EXPECT_EQ(offscreen->cams[0]->width_, 72);
+	EXPECT_EQ(offscreen->cams[0]->height_, 48);
+
+	env_ptr->step(1);
+	// Wait for image to be published with 100ms timeout
+	float seconds = 0;
+	while (rgb_images.size() == 0 && seconds < .1) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		seconds += 0.001;
+	}
+	EXPECT_LT(seconds, .1) << "RGB image not published within 100ms";
+
+	ASSERT_EQ(cam_infos.size(), 1);
+	ASSERT_EQ(rgb_images.size(), 1);
+
+	ros::Time t1 = ros::Time::now();
+	EXPECT_EQ(rgb_images[0].header.stamp, t1);
+	EXPECT_EQ(rgb_images[0].header.frame_id, "test_cam_optical_frame");
+	EXPECT_EQ(rgb_images[0].width, 72);
+	EXPECT_EQ(rgb_images[0].height, 48);
+	EXPECT_EQ(rgb_images[0].encoding, sensor_msgs::image_encodings::RGB8);
+
+	EXPECT_EQ(cam_infos[0].header.stamp, t1);
+
+	rgb_images.clear();
+	cam_infos.clear();
+
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, Cam_Timing_Correct)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("unpause", false);
+	nh->setParam("cam_config/test_cam/frequency", 30);
+	nh->setParam("cam_config/test_cam/width", 72);
+	nh->setParam("cam_config/test_cam/height", 48);
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	// Clear image buffers
+	rgb_images.clear();
+	cam_infos.clear();
+
+	// Subscribe to topic
+	ros::Subscriber rgb_sub  = nh->subscribe("cameras/test_cam/rgb", 1, rgb_cb);
+	ros::Subscriber info_sub = nh->subscribe("cameras/test_cam/camera_info", 1, cam_info_cb);
+
+	env_ptr->startWithXML(xml_path);
+
+	EXPECT_TRUE(env_ptr->settings_.headless);
+	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
+
+	env_ptr->step(1);
+	// Wait for image to be published with 100ms timeout
+	float seconds = 0;
+	while (rgb_images.size() == 0 && seconds < .1) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		seconds += 0.001;
+	}
+	EXPECT_LT(seconds, .1) << "RGB image not published within 100ms";
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+
+	// Check default camera settings
+	EXPECT_EQ(offscreen->cams[0]->cam_id_, 0);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_EQ(offscreen->cams[0]->stream_type_, rendering::streamType::RGB);
+	EXPECT_EQ(offscreen->cams[0]->pub_freq_, 30);
+
+	// Wait for image to be published with 100ms timeout
+	seconds = 0;
+	while (rgb_images.size() == 0 && seconds < 0.1) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		seconds += 0.001;
+	}
+	EXPECT_LT(seconds, 0.1) << "RGB image not published within 100ms";
+
+	ASSERT_EQ(cam_infos.size(), 1);
+	ASSERT_EQ(rgb_images.size(), 1);
+
+	ros::Time t1 = ros::Time::now();
+	// Step the simulation to as to trigger the camera rendering
+	mjModel *m = env_ptr->getModelPtr();
+	ROS_INFO_STREAM("Next pub time will be " << (1.0 / 30.0) << " seconds from now. Thus in "
+	                                         << std::ceil((1.0 / 30.0) / m->opt.timestep) << " steps.");
+	int n_steps = std::ceil((1.0 / 30.0) / env_ptr->getModelPtr()->opt.timestep);
+
+	env_ptr->step(n_steps - 1);
+	// wait a little
+	std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+	// should not have received a new image yet
+	ASSERT_EQ(cam_infos.size(), 1);
+	ASSERT_EQ(rgb_images.size(), 1);
+
+	env_ptr->step(1);
+	// Wait for image to be published with 100ms timeout
+	seconds = 0;
+	while (rgb_images.size() < 2 && seconds < 0.1) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		seconds += 0.001;
+	}
+	// should now have received new image
+	EXPECT_LT(seconds, 0.1) << "RGB image not published within 100ms";
+
+	ASSERT_EQ(cam_infos.size(), 2);
+	ASSERT_EQ(rgb_images.size(), 2);
+	ros::Time t2 = ros::Time::now();
+
+	ASSERT_EQ(rgb_images[0].header.stamp, t1);
+	ASSERT_EQ(rgb_images[1].header.stamp, t2);
+
+	ASSERT_EQ(cam_infos[0].header.stamp, t1);
+	ASSERT_EQ(cam_infos[1].header.stamp, t2);
+
+	// int n_steps = std::ceil((1.0 / 30.0) / env_ptr->getModelPtr()->opt.timestep);
+	ros::Time t3 = t2 + ros::Duration((std::ceil((1.0 / 30.0) / m->opt.timestep)) * m->opt.timestep);
+	// ros::Time t3 = t2 + (t2 - t1);
+	// Step over next image trigger but before trigger after that
+	env_ptr->step(2 * n_steps - 1);
+
+	ASSERT_EQ(cam_infos.size(), 3);
+	ASSERT_EQ(rgb_images.size(), 3);
+
+	// Check that the timestamps are as expected
+	EXPECT_EQ(rgb_images[2].header.stamp, cam_infos[2].header.stamp);
+	EXPECT_EQ(rgb_images[2].header.stamp, t3);
+	EXPECT_EQ(cam_infos[2].header.stamp, t3);
+
+	rgb_images.clear();
+	cam_infos.clear();
+
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, RGB_Image_Dtype)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("unpause", false);
+	nh->setParam("cam_config/test_cam/width", 72);
+	nh->setParam("cam_config/test_cam/height", 48);
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	// Clear image buffers
+	rgb_images.clear();
+
+	// Subscribe to topic
+	ros::Subscriber rgb_sub = nh->subscribe("cameras/test_cam/rgb", 1, rgb_cb);
+
+	env_ptr->startWithXML(xml_path);
+
+	EXPECT_TRUE(env_ptr->settings_.headless);
+	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
+
+	env_ptr->step(1);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_EQ(offscreen->cams[0]->stream_type_, rendering::streamType::RGB);
+	EXPECT_EQ(offscreen->cams[0]->width_, 72);
+	EXPECT_EQ(offscreen->cams[0]->height_, 48);
+
+	// Wait for image to be published with 100ms timeout
+	float seconds = 0;
+	while (rgb_images.size() == 0 && seconds < .1) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		seconds += 0.001;
+	}
+	EXPECT_LT(seconds, .1) << "RGB image not published within 100ms";
+
+	ASSERT_EQ(rgb_images.size(), 1);
+	EXPECT_EQ(rgb_images[0].data.size(), 72 * 48 * 3);
+	EXPECT_EQ(rgb_images[0].encoding, sensor_msgs::image_encodings::RGB8);
+
+	rgb_images.clear();
+
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, DEPTH_Image_Dtype)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("unpause", false);
+	nh->setParam("cam_config/test_cam/stream_type", rendering::streamType::DEPTH);
+	nh->setParam("cam_config/test_cam/width", 72);
+	nh->setParam("cam_config/test_cam/height", 48);
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	// Clear image buffers
+	depth_images.clear();
+
+	// Subscribe to topic
+	ros::Subscriber depth_sub = nh->subscribe("cameras/test_cam/depth", 1, depth_cb);
+
+	env_ptr->startWithXML(xml_path);
+
+	EXPECT_TRUE(env_ptr->settings_.headless);
+	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
+
+	env_ptr->step(1);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_EQ(offscreen->cams[0]->stream_type_, rendering::streamType::DEPTH);
+	EXPECT_EQ(offscreen->cams[0]->width_, 72);
+	EXPECT_EQ(offscreen->cams[0]->height_, 48);
+
+	// Wait for image to be published with 100ms timeout
+	float seconds = 0;
+	while (depth_images.size() == 0 && seconds < .1) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		seconds += 0.001;
+	}
+	EXPECT_LT(seconds, .1) << "Depth image not published within 100ms";
+
+	ASSERT_EQ(depth_images.size(), 1);
+	EXPECT_EQ(depth_images[0].width, 72);
+	EXPECT_EQ(depth_images[0].height, 48);
+	EXPECT_EQ(depth_images[0].encoding, sensor_msgs::image_encodings::TYPE_32FC1);
+
+	depth_images.clear();
+	env_ptr->shutdown();
+}
+
+TEST_F(BaseEnvFixture, SEGMENTED_Image_Dtype)
+{
+	nh->setParam("no_render", false);
+	nh->setParam("headless", true);
+	nh->setParam("unpause", false);
+	nh->setParam("cam_config/test_cam/stream_type", rendering::streamType::SEGMENTED);
+	nh->setParam("cam_config/test_cam/width", 72);
+	nh->setParam("cam_config/test_cam/height", 48);
+
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	// Clear image buffers
+	seg_images.clear();
+
+	// Subscribe to topic
+	ros::Subscriber seg_sub = nh->subscribe("cameras/test_cam/segmented", 1, seg_cb);
+
+	env_ptr->startWithXML(xml_path);
+
+	EXPECT_TRUE(env_ptr->settings_.headless);
+	EXPECT_TRUE(env_ptr->settings_.render_offscreen);
+
+	env_ptr->step(1);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	ASSERT_EQ(offscreen->cams.size(), 1);
+	EXPECT_STREQ(offscreen->cams[0]->cam_name_.c_str(), "test_cam");
+	EXPECT_EQ(offscreen->cams[0]->stream_type_, rendering::streamType::SEGMENTED);
+	EXPECT_EQ(offscreen->cams[0]->width_, 72);
+	EXPECT_EQ(offscreen->cams[0]->height_, 48);
+
+	// Wait for image to be published with 100ms timeout
+	float seconds = 0;
+	while (seg_images.size() == 0 && seconds < .1) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		seconds += 0.001;
+	}
+	EXPECT_LT(seconds, .1) << "Segmentation image not published within 100ms";
+
+	ASSERT_EQ(seg_images.size(), 1);
+	EXPECT_EQ(seg_images[0].data.size(), 72 * 48 * 1);
+
+	seg_images.clear();
+	env_ptr->shutdown();
+}
+
+#endif // defined(USE_GLFW) || defined(USE_EGL) || defined(USE_OSMESA) // i.e. any render backend available
+
+#if !defined(USE_GLFW) && !defined(USE_EGL) && !defined(USE_OSMESA) // i.e. no render backend available
+TEST_F(BaseEnvFixture, No_Render_Backend_Headless_Warn)
+{
+	nh->setParam("headless", true);
+	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/camera_world.xml";
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
+
+	env_ptr->startWithXML(xml_path);
+
+	while (env_ptr->getOperationalStatus() != 0) { // wait for model to be loaded
+		std::this_thread::sleep_for(std::chrono::milliseconds(3));
+	}
+
+	EXPECT_TRUE(env_ptr->settings_.headless);
+	EXPECT_FALSE(env_ptr->settings_.render_offscreen);
+
+	OffscreenRenderContext *offscreen = env_ptr->getOffscreenContext();
+	EXPECT_TRUE(offscreen->cams.size() == 0);
+
+	env_ptr->shutdown();
+}
+#endif // !defined(USE_GLFW) && !defined(USE_EGL) && !defined(USE_OSMESA) // i.e. no render backend available
+
+// TODOs:
+// - Tests for offscreen rendering
+//   + Test if RGB topic is available (done)
+//   + Test if Depth topic is available (done)
+//   + Test if Segmentation topic is available (done)
+//   + Test if CameraInfo topic is available
+//   + Test default camera settings
+//   + Resolution settings
+//   + test all combinations of RGB, Depth, and Segmentation (done)
+//   + Test that camera timings are correct by stepping through the simulation and checking the timestamps
+//   + Test camera image data types

--- a/mujoco_ros/test/mujoco_render_test.cpp
+++ b/mujoco_ros/test/mujoco_render_test.cpp
@@ -125,7 +125,8 @@ TEST_F(BaseEnvFixture, Not_Headless_Warn)
 	env_ptr->shutdown();
 }
 
-#if defined(USE_GLFW) || defined(USE_EGL) || defined(USE_OSMESA) // i.e. any render backend available
+#if RENDER_BACKEND == USE_GLFW || RENDER_BACKEND == USE_EGL || \
+    RENDER_BACKEND == USE_OSMESA // i.e. any render backend available
 TEST_F(BaseEnvFixture, NoRender_Params_Correct)
 {
 	nh->setParam("no_render", true);
@@ -1003,9 +1004,10 @@ TEST_F(BaseEnvFixture, SEGMENTED_Image_Dtype)
 	env_ptr->shutdown();
 }
 
-#endif // defined(USE_GLFW) || defined(USE_EGL) || defined(USE_OSMESA) // i.e. any render backend available
+#endif // RENDER_BACKEND == USE_GLFW || RENDER_BACKEND == USE_EGL || RENDER_BACKEND == USE_OSMESA // i.e. any render
+       // backend available
 
-#if !defined(USE_GLFW) && !defined(USE_EGL) && !defined(USE_OSMESA) // i.e. no render backend available
+#if RENDER_BACKEND == USE_NONE // i.e. no render backend available
 TEST_F(BaseEnvFixture, No_Render_Backend_Headless_Warn)
 {
 	nh->setParam("headless", true);
@@ -1026,7 +1028,7 @@ TEST_F(BaseEnvFixture, No_Render_Backend_Headless_Warn)
 
 	env_ptr->shutdown();
 }
-#endif // !defined(USE_GLFW) && !defined(USE_EGL) && !defined(USE_OSMESA) // i.e. no render backend available
+#endif // RENDER_BACKEND == USE_NONE // i.e. no render backend available
 
 // TODOs:
 // - Tests for offscreen rendering

--- a/mujoco_ros/test/mujoco_ros_plugin_test.cpp
+++ b/mujoco_ros/test/mujoco_ros_plugin_test.cpp
@@ -147,20 +147,20 @@ TEST_F(BaseEnvFixture, LoadPlugin)
 {
 	nh->setParam("unpause", false);
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	MujocoEnvTestWrapper env;
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
 
-	env.startWithXML(xml_path);
+	env_ptr->startWithXML(xml_path);
 
 	float seconds = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) {
+	while (env_ptr->getOperationalStatus() != 0 && seconds < 2) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
 		seconds += 0.001;
 	}
 	EXPECT_LT(seconds, 2) << "Env loading ran into 2 seconds timeout!";
-	EXPECT_EQ(env.getPlugins().size(), 1) << "Env should have 1 plugin registered!";
-	EXPECT_EQ(env.getNumCBReadyPlugins(), 1) << "Env should have 1 plugin loaded!";
+	EXPECT_EQ(env_ptr->getPlugins().size(), 1) << "Env should have 1 plugin registered!";
+	EXPECT_EQ(env_ptr->getNumCBReadyPlugins(), 1) << "Env should have 1 plugin loaded!";
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(LoadedPluginFixture, ResetPlugin)
@@ -200,24 +200,24 @@ TEST_F(BaseEnvFixture, FailedLoad)
 	nh->setParam("should_fail", true);
 
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	MujocoEnvTestWrapper env;
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
 
-	env.startWithXML(xml_path);
+	env_ptr->startWithXML(xml_path);
 
 	float seconds = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) {
+	while (env_ptr->getOperationalStatus() != 0 && seconds < 2) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
 		seconds += 0.001;
 	}
 	EXPECT_LT(seconds, 2) << "Env loading ran into 2 seconds timeout!";
 
-	EXPECT_EQ(env.getPlugins().size(), 1) << "Env should have 1 plugin registered!";
-	EXPECT_EQ(env.getNumCBReadyPlugins(), 0) << "Env should have 0 plugins loaded!";
+	EXPECT_EQ(env_ptr->getPlugins().size(), 1) << "Env should have 1 plugin registered!";
+	EXPECT_EQ(env_ptr->getNumCBReadyPlugins(), 0) << "Env should have 0 plugins loaded!";
 
 	{
 		TestPlugin *test_plugin = nullptr;
 
-		auto &plugins = env.getPlugins();
+		auto &plugins = env_ptr->getPlugins();
 		for (const auto &p : plugins) {
 			test_plugin = dynamic_cast<TestPlugin *>(p.get());
 			if (test_plugin != nullptr) {
@@ -234,7 +234,7 @@ TEST_F(BaseEnvFixture, FailedLoad)
 		EXPECT_FALSE(test_plugin->ran_on_geom_changed_cb.load());
 	}
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, FailedLoadRecoverReload)
@@ -242,24 +242,24 @@ TEST_F(BaseEnvFixture, FailedLoadRecoverReload)
 	nh->setParam("should_fail", true);
 
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	MujocoEnvTestWrapper env;
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
 
-	env.startWithXML(xml_path);
+	env_ptr->startWithXML(xml_path);
 
 	float seconds = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) {
+	while (env_ptr->getOperationalStatus() != 0 && seconds < 2) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
 		seconds += 0.001;
 	}
 	EXPECT_LT(seconds, 2) << "Env loading ran into 2 seconds timeout!";
 
-	EXPECT_EQ(env.getPlugins().size(), 1) << "Env should have 1 plugin registered!";
-	EXPECT_EQ(env.getNumCBReadyPlugins(), 0) << "Env should have 0 plugins loaded!";
+	EXPECT_EQ(env_ptr->getPlugins().size(), 1) << "Env should have 1 plugin registered!";
+	EXPECT_EQ(env_ptr->getNumCBReadyPlugins(), 0) << "Env should have 0 plugins loaded!";
 
 	{
 		TestPlugin *test_plugin = nullptr;
 
-		auto &plugins = env.getPlugins();
+		auto &plugins = env_ptr->getPlugins();
 		for (const auto &p : plugins) {
 			test_plugin = dynamic_cast<TestPlugin *>(p.get());
 			if (test_plugin != nullptr) {
@@ -269,18 +269,18 @@ TEST_F(BaseEnvFixture, FailedLoadRecoverReload)
 
 		nh->setParam("should_fail", false);
 
-		env.settings_.load_request = 2;
-		float seconds              = 0;
-		while (env.getOperationalStatus() != 0 && seconds < 2) {
+		env_ptr->settings_.load_request = 2;
+		float seconds                   = 0;
+		while (env_ptr->getOperationalStatus() != 0 && seconds < 2) {
 			std::this_thread::sleep_for(std::chrono::milliseconds(1));
 			seconds += 0.001;
 		}
 		EXPECT_LT(seconds, 2) << "Env reset ran into 2 seconds timeout!";
-		EXPECT_EQ(env.getPlugins().size(), 1) << "Env should have 1 plugin registered!";
-		EXPECT_EQ(env.getNumCBReadyPlugins(), 1) << "Env should have 1 plugin loaded!";
+		EXPECT_EQ(env_ptr->getPlugins().size(), 1) << "Env should have 1 plugin registered!";
+		EXPECT_EQ(env_ptr->getNumCBReadyPlugins(), 1) << "Env should have 1 plugin loaded!";
 	}
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(BaseEnvFixture, FailedLoadReset)
@@ -289,24 +289,24 @@ TEST_F(BaseEnvFixture, FailedLoadReset)
 	nh->setParam("unpause", false);
 
 	std::string xml_path = ros::package::getPath("mujoco_ros") + "/test/empty_world.xml";
-	MujocoEnvTestWrapper env;
+	env_ptr              = std::make_unique<MujocoEnvTestWrapper>("");
 
-	env.startWithXML(xml_path);
+	env_ptr->startWithXML(xml_path);
 
 	float seconds = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) {
+	while (env_ptr->getOperationalStatus() != 0 && seconds < 2) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
 		seconds += 0.001;
 	}
 	EXPECT_LT(seconds, 2) << "Env loading ran into 2 seconds timeout!";
 
-	EXPECT_EQ(env.getPlugins().size(), 1) << "Env should have 1 plugin registered!";
-	EXPECT_EQ(env.getNumCBReadyPlugins(), 0) << "Env should have 0 plugins loaded!";
+	EXPECT_EQ(env_ptr->getPlugins().size(), 1) << "Env should have 1 plugin registered!";
+	EXPECT_EQ(env_ptr->getNumCBReadyPlugins(), 0) << "Env should have 0 plugins loaded!";
 
 	{
 		TestPlugin *test_plugin = nullptr;
 
-		auto &plugins = env.getPlugins();
+		auto &plugins = env_ptr->getPlugins();
 		for (const auto &p : plugins) {
 			test_plugin = dynamic_cast<TestPlugin *>(p.get());
 			if (test_plugin != nullptr) {
@@ -314,19 +314,19 @@ TEST_F(BaseEnvFixture, FailedLoadReset)
 			}
 		}
 
-		env.settings_.reset_request = 1;
-		float seconds               = 0;
-		while (env.settings_.reset_request != 0 && seconds < 2) {
+		env_ptr->settings_.reset_request = 1;
+		float seconds                    = 0;
+		while (env_ptr->settings_.reset_request != 0 && seconds < 2) {
 			std::this_thread::sleep_for(std::chrono::milliseconds(1));
 			seconds += 0.001;
 		}
 		EXPECT_LT(seconds, 2) << "Env reset ran into 2 seconds timeout!";
-		env.step(10);
+		env_ptr->step(10);
 
 		EXPECT_FALSE(test_plugin->ran_reset.load()) << "Dummy plugin should not have beeon reset!";
 	}
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(LoadedPluginFixture, PluginStats_InitialPaused)

--- a/mujoco_ros/test/mujoco_ros_plugin_test.cpp
+++ b/mujoco_ros/test/mujoco_ros_plugin_test.cpp
@@ -235,7 +235,6 @@ TEST_F(BaseEnvFixture, FailedLoad)
 	}
 
 	env.shutdown();
-	nh->setParam("should_fail", false);
 }
 
 TEST_F(BaseEnvFixture, FailedLoadRecoverReload)
@@ -328,7 +327,6 @@ TEST_F(BaseEnvFixture, FailedLoadReset)
 	}
 
 	env.shutdown();
-	nh->setParam("should_fail", false);
 }
 
 TEST_F(LoadedPluginFixture, PluginStats_InitialPaused)

--- a/mujoco_ros/test/ros_interface_test.cpp
+++ b/mujoco_ros/test/ros_interface_test.cpp
@@ -443,10 +443,6 @@ TEST_F(BaseEnvFixture, CustomInitialJointStates)
 	compare_qvel(d, m->jnt_dofadr[id_free], "ball_freejoint", { 1.0, 2.0, 3.0, 10.0, 20.0, 30.0 });
 
 	env.shutdown();
-
-	nh->deleteParam("initial_joint_positions/joint_map");
-	nh->deleteParam("initial_joint_velocities/joint_map");
-	nh->setParam("unpause", true);
 }
 
 TEST_F(PendulumEnvFixture, CustomInitialJointStatesOnReset)

--- a/mujoco_ros/test/ros_interface_test.cpp
+++ b/mujoco_ros/test/ros_interface_test.cpp
@@ -409,15 +409,15 @@ TEST_F(BaseEnvFixture, CustomInitialJointStates)
 	nh->setParam("initial_joint_positions/joint_map", pos_map);
 	nh->setParam("initial_joint_velocities/joint_map", vel_map);
 
-	MujocoEnvTestWrapper env;
-	env.startWithXML(xml_path);
+	env_ptr = std::make_unique<MujocoEnvTestWrapper>("");
+	env_ptr->startWithXML(xml_path);
 
-	while (env.getOperationalStatus() > 0) { // wait for reset to be done
+	while (env_ptr->getOperationalStatus() > 0) { // wait for reset to be done
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
 	}
 
-	mjData *d  = env.getDataPtr();
-	mjModel *m = env.getModelPtr();
+	mjData *d  = env_ptr->getDataPtr();
+	mjModel *m = env_ptr->getModelPtr();
 
 	int id_balljoint, id1, id2, id_free;
 
@@ -442,7 +442,7 @@ TEST_F(BaseEnvFixture, CustomInitialJointStates)
 	compare_qvel(d, m->jnt_dofadr[id2], "joint2", { 1.05 });
 	compare_qvel(d, m->jnt_dofadr[id_free], "ball_freejoint", { 1.0, 2.0, 3.0, 10.0, 20.0, 30.0 });
 
-	env.shutdown();
+	env_ptr->shutdown();
 }
 
 TEST_F(PendulumEnvFixture, CustomInitialJointStatesOnReset)

--- a/mujoco_ros/test/test_util.h
+++ b/mujoco_ros/test/test_util.h
@@ -39,11 +39,11 @@
 #include <mujoco_ros/common_types.h>
 using namespace mujoco_ros;
 
-void load_queued_model(MujocoEnv &env)
+void load_queued_model(MujocoEnv *env)
 {
-	env.settings_.load_request = 2;
-	float seconds              = 0;
-	while (env.getOperationalStatus() != 0 && seconds < 2) { // wait for model to be loaded or timeout
+	env->settings_.load_request = 2;
+	float seconds               = 0;
+	while (env->getOperationalStatus() != 0 && seconds < 2) { // wait for model to be loaded or timeout
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
 		seconds += 0.001;
 	}

--- a/mujoco_ros_laser/test/mujoco_env_wrapper.h
+++ b/mujoco_ros_laser/test/mujoco_env_wrapper.h
@@ -77,7 +77,7 @@ public:
 
 	const std::string &getHandleNamespace() { return nh_->getNamespace(); }
 
-	void startWithXML(const std::string &xml_path)
+	void startWithXML(const std::string &xml_path, bool wait = false)
 	{
 		mju::strcpy_arr(queued_filename_, xml_path.c_str());
 		settings_.load_request = 2;

--- a/mujoco_ros_sensors/test/mujoco_sensors_test.cpp
+++ b/mujoco_ros_sensors/test/mujoco_sensors_test.cpp
@@ -36,6 +36,7 @@
 
 #include <gtest/gtest.h>
 
+#include <mujoco_ros/render_backend.h>
 #include <mujoco_ros/mujoco_env.h>
 #include <mujoco_ros/common_types.h>
 #include <mujoco_ros_sensors/mujoco_sensor_handler_plugin.h>


### PR DESCRIPTION
### Description

camera_info needs to have the same timestamp as the images. (e.g. for usage with `message_filters.TimeSynchronizer`)

- give each image from cameras its own CameraInfo
- add configuration for camera topics
    
This changes cameras to publish a syncronized camera_info for each image. e.g for rgb image:
    `/mujoco_server/cameras/camera_name/rgb/camera_info`
    `/mujoco_server/cameras/camera_name/rgb/image_raw`
    
Additional configuration options to change topics:
      `camera_name/topic`: defaults to "/mujoco_server/cameras/camera_name"
      `camera_name/name_rgb`: default to "rbg"
      `camera_name/name_depth`: default to "depth"
      `camera_name/name_segment`: default to "segmented"

### Checklist
- [ ] **Required by CI**: Code is auto formatted using clang-format.
- [ ] Add a brief explanation of your changes to the [changelog](CHANGELOG.md).
