### PR TITLE
Add camera topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The default is `min(#available_threads - 1, 4)`.
 * Added profiling of plugin load and callback execution times. For each callback an EMA with sensitivity of 1000 steps is computed. In case a plugin has lower frequency than simulation step size, the callback should set `skip_ema_ = true` when skipping computations.
 Loading and reset times are reported in the server debug log. All plugin stats can be retrieved by the `get_plugin_stats` service call.
 * Added ros laser plugin.
+* Added topic parameter to cameras.
 
 ### Fixed
 * Added missing call to render callbacks in viewer. While the callbacks were still being run for offscreen rendering, the viewer did not render additional geoms added by plugins.

--- a/mujoco_ros/include/mujoco_ros/offscreen_camera.h
+++ b/mujoco_ros/include/mujoco_ros/offscreen_camera.h
@@ -53,8 +53,8 @@ namespace mujoco_ros::rendering {
 class OffscreenCamera
 {
 public:
-	OffscreenCamera(const uint8_t cam_id, const std::string &cam_name, const int width, const int height,
-	                const streamType stream_type, const bool use_segid, const float pub_freq,
+	OffscreenCamera(const uint8_t cam_id, const std::string &base_topic, const std::string &cam_name, const int width,
+	                const int height, const streamType stream_type, const bool use_segid, const float pub_freq,
 	                image_transport::ImageTransport *it, const ros::NodeHandle &parent_nh, const mjModel *model,
 	                mjData *data, mujoco_ros::MujocoEnv *env_ptr);
 
@@ -71,6 +71,7 @@ public:
 
 	uint8_t cam_id_;
 	std::string cam_name_;
+	std::string topic_;
 	int width_, height_;
 	streamType stream_type_ = streamType::RGB;
 	bool use_segid_         = true;

--- a/mujoco_ros/src/offscreen_camera.cpp
+++ b/mujoco_ros/src/offscreen_camera.cpp
@@ -47,10 +47,11 @@
 
 namespace mujoco_ros::rendering {
 
-OffscreenCamera::OffscreenCamera(const uint8_t cam_id, const std::string &cam_name, const int width, const int height,
-                                 const streamType stream_type, const bool use_segid, const float pub_freq,
-                                 image_transport::ImageTransport *it, const ros::NodeHandle &parent_nh,
-                                 const mjModel *model, mjData *data, mujoco_ros::MujocoEnv *env_ptr)
+OffscreenCamera::OffscreenCamera(const uint8_t cam_id, const std::string &base_topic, const std::string &cam_name,
+                                 const int width, const int height, const streamType stream_type, const bool use_segid,
+                                 const float pub_freq, image_transport::ImageTransport *it,
+                                 const ros::NodeHandle &parent_nh, const mjModel *model, mjData *data,
+                                 mujoco_ros::MujocoEnv *env_ptr)
     : cam_id_(cam_id)
     , cam_name_(cam_name)
     , width_(width)
@@ -60,7 +61,7 @@ OffscreenCamera::OffscreenCamera(const uint8_t cam_id, const std::string &cam_na
     , pub_freq_(pub_freq)
 {
 	last_pub_ = ros::Time::now();
-	ros::NodeHandle nh(parent_nh, "cameras/" + cam_name);
+	ros::NodeHandle nh(parent_nh, base_topic);
 
 	mjv_defaultOption(&vopt_);
 	mjv_defaultSceneState(&scn_state_);
@@ -68,15 +69,15 @@ OffscreenCamera::OffscreenCamera(const uint8_t cam_id, const std::string &cam_na
 
 	if (stream_type & streamType::RGB) {
 		ROS_DEBUG_NAMED("mujoco_env", "\tCreating rgb publisher");
-		rgb_pub_ = it->advertise("cameras/" + cam_name + "/rgb", 1);
+		rgb_pub_ = it->advertise(base_topic + "/rgb", 1);
 	}
 	if (stream_type & streamType::DEPTH) {
 		ROS_DEBUG_NAMED("mujoco_env", "\tCreating depth publisher");
-		depth_pub_ = it->advertise("cameras/" + cam_name + "/depth", 1);
+		depth_pub_ = it->advertise(base_topic + "/depth", 1);
 	}
 	if (stream_type & streamType::SEGMENTED) {
 		ROS_DEBUG_NAMED("mujoco_env", "\tCreating segmentation publisher");
-		segment_pub_ = it->advertise("cameras/" + cam_name + "/segmented", 1);
+		segment_pub_ = it->advertise(base_topic + "/segmented", 1);
 	}
 
 	ROS_DEBUG_STREAM_NAMED("mujoco_env", "\tSetting up camera stream(s) of type '"

--- a/mujoco_ros/src/offscreen_rendering.cpp
+++ b/mujoco_ros/src/offscreen_rendering.cpp
@@ -57,7 +57,7 @@ void MujocoEnv::initializeRenderResources()
 	image_transport::ImageTransport it(*nh_);
 	bool config_exists, use_segid;
 	rendering::streamType stream_type;
-	std::string cam_name, cam_config_path;
+	std::string cam_name, cam_config_path, base_topic;
 	float pub_freq;
 	int max_res_h = 0, max_res_w = 0;
 
@@ -92,19 +92,22 @@ void MujocoEnv::initializeRenderResources()
 		res_w_string += "/width";
 		std::string res_h_string(param_path);
 		res_h_string += "/height";
+		std::string base_topic_string(param_path);
+		base_topic_string += "/topic";
 
 		stream_type = rendering::streamType(this->nh_->param<int>(stream_type_string, rendering::streamType::RGB));
 		pub_freq    = this->nh_->param<float>(pub_freq_string, 15);
 		use_segid   = this->nh_->param<bool>(segid_string, true);
 		res_w       = this->nh_->param<int>(res_w_string, 720);
 		res_h       = this->nh_->param<int>(res_h_string, 480);
+		base_topic  = this->nh_->param<std::string>(base_topic_string, "cameras/" + cam_name);
 
 		max_res_h = std::max(res_h, max_res_h);
 		max_res_w = std::max(res_w, max_res_w);
 
-		offscreen_.cams.emplace_back(std::make_unique<rendering::OffscreenCamera>(cam_id, cam_name, res_w, res_h,
-		                                                                          stream_type, use_segid, pub_freq, &it,
-		                                                                          *nh_, model_.get(), data_.get(), this));
+		offscreen_.cams.emplace_back(std::make_unique<rendering::OffscreenCamera>(
+		    cam_id, base_topic, cam_name, res_w, res_h, stream_type, use_segid, pub_freq, &it, *nh_, model_.get(),
+		    data_.get(), this));
 	}
 
 	if (model_->vis.global.offheight < max_res_h || model_->vis.global.offwidth < max_res_w) {


### PR DESCRIPTION
### Description

- Add a topic parameter to cameras to change topic prefixes

I am still looking at different REPs and package descriptions to find out if the image has  to be published on `base_topic/rgb/image` instead of `base_topic/rgb` which could also require `camera_info` to be send twice.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using clang-format.
- [ ] Add a brief explanation of your changes to the [changelog](CHANGELOG.md).
