### PR TITLE
fix: unify headless exit chain and prevent double-spinning in ROS2

### DIFF
--- a/mujoco_ros/src/main.cpp
+++ b/mujoco_ros/src/main.cpp
@@ -73,16 +73,6 @@ using Seconds = std::chrono::duration<double>;
 
 } // anonymous namespace
 
-#if MJR_ROS_VERSION == ROS_2
-static bool should_exit = false;
-void async_spin(const rclcpp::executors::MultiThreadedExecutor::SharedPtr &executor)
-{
-	while (!should_exit) {
-		executor->spin_some();
-		std::this_thread::sleep_for(Seconds(0.01));
-	}
-}
-#endif
 
 int main(int argc, char **argv)
 {
@@ -142,37 +132,46 @@ int main(int argc, char **argv)
 	env->StartPhysicsLoop();
 	env->StartEventLoop();
 
+#if MJR_ROS_VERSION == ROS_2
+	// Start the background executor thread immediately.
+	// This provides the heartbeat for services like controller_manager,
+	// even if we are running in headless mode.
+	std::thread executor_thread([&executor]() {
+		executor->spin();
+	});
+#endif
+
 #if RENDER_BACKEND == GLFW_BACKEND
 	if (!env->settings_.headless) {
 		MJR_INFO("Launching viewer");
 		auto viewer = std::make_unique<mujoco_ros::Viewer>(
-		    std::unique_ptr<mujoco_ros::PlatformUIAdapter>(env->gui_adapter_), env.get(), /* is_passive = */ false);
-#if MJR_ROS_VERSION == ROS_1
-		viewer->RenderLoop();
-#else // MJR_ROS_VERSION == ROS_2
-      // TODO: This is a workaround for running a blocking viewer and a blocking executor in ROS 2.
-      // Running the render loop in a separate thread does not work. The otherway around does, but
-      // I'm not sure this is ideal.
-		std::thread executor_thread = std::thread(std::bind(&async_spin, std::ref(executor)));
+		    std::unique_ptr<mujoco_ros::PlatformUIAdapter>(env->gui_adapter_), env.get(), false);
+
+		// Main thread blocks here for GUI
 		viewer->RenderLoop();
 		MJR_INFO("Viewer terminated");
-		MJR_DEBUG("Joining executor thread");
-		should_exit = true;
-		executor_thread.join();
-		MJR_DEBUG("Joined executor thread");
-#endif
 	}
-#else
-	MJR_ERROR_COND(!env->settings_.headless, "GLFW backend not available. Cannot launch viewer");
-#endif
-	MJR_INFO_COND(env->settings_.headless, "Running headless");
-
-#if MJR_ROS_VERSION == ROS_2 && RENDER_BACKEND != GLFW_BACKEND
-	executor->spin();
 #endif
 
-	env->WaitForPhysicsJoin();
+	if (env->settings_.headless) {
+		MJR_INFO("Running headless. Main thread waiting for shutdown request...");
+		env->WaitForPhysicsJoin();
+	}
+
+	env->settings_.exit_request.store(1);
+
+#if MJR_ROS_VERSION == ROS_2
+	rclcpp::shutdown();
+#endif
+
 	env->WaitForEventsJoin();
+
+#if MJR_ROS_VERSION == ROS_2
+	if (executor_thread.joinable()) {
+		executor_thread.join();
+	}
+#endif
+
 	env.reset();
 
 	MJR_INFO("MuJoCo ROS Simulation Server node is terminating");
@@ -180,8 +179,8 @@ int main(int argc, char **argv)
 #if MJR_ROS_VERSION == ROS_1
 	spinner.stop();
 	ros::shutdown();
-#else // MJR_ROS_VERSION == ROS_2
-	rclcpp::shutdown();
 #endif
-	exit(0);
+
+	return 0;
 }
+

--- a/mujoco_ros/src/physics.cpp
+++ b/mujoco_ros/src/physics.cpp
@@ -99,9 +99,8 @@ void MujocoEnv::PhysicsLoop()
 	}
 	is_physics_running_ = 0;
 	MJR_INFO_COND(num_steps_until_exit_ == 0, "Reached requested number of steps. Exiting simulation");
-	// settings_.exit_request.store(1);
-	if (offscreen_.render_thread_handle.joinable()) {
-		offscreen_.cond_render_request.notify_one();
+	settings_.exit_request.store(1);
+	if (offscreen_.render_thread_handle.joinable()) {		offscreen_.cond_render_request.notify_one();
 		MJR_DEBUG("Joining offscreen render thread");
 		offscreen_.render_thread_handle.join();
 	}

--- a/mujoco_ros2_control/src/mujoco_ros2_control.cpp
+++ b/mujoco_ros2_control/src/mujoco_ros2_control.cpp
@@ -33,9 +33,15 @@ std::string MujocoRos2ControlPluginPrivate::getURDF() const
 	while (urdf_string.empty()) {
 		try {
 			auto f = parameters_client->get_parameters({ this->robot_description_ });
-			executor_->spin_until_future_complete(f);
-			std::vector<rclcpp::Parameter> values = f.get();
-			urdf_string                           = values[0].as_string();
+			// Let the background executor handle the communication.
+			auto status = f.wait_for(std::chrono::seconds(5));
+			if (status == std::future_status::ready) {
+				std::vector<rclcpp::Parameter> values = f.get();
+				urdf_string                           = values[0].as_string();
+			} else {
+				RCLCPP_ERROR(node_->get_logger(), "Service 'robot_description' timed out. "
+				                                 "Ensure robot_state_publisher is running.");
+			}
 		} catch (const std::exception &e) {
 			RCLCPP_ERROR(node_->get_logger(), "%s", e.what());
 		}
@@ -268,3 +274,4 @@ void MujocoRos2ControlPlugin::Reset()
 
 #include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(mujoco_ros2_control::MujocoRos2ControlPlugin, mujoco_ros::MujocoPlugin)
+


### PR DESCRIPTION
This commit addresses issues in the ROS2 headless mode:

1. Unified headless / ROS2 exit sequence
   - The executor thread is started early to ensure controller/service heartbeats are present even without a viewer.
   - The main thread correctly sets `settings_.exit_request.store(1)` and waits for event and physics loops.

2. Fixed step-limit exit chain
   - When `num_steps_until_exit_ == 0`, `settings_.exit_request` is now explicitly set in `physics.cpp` so the event loop does not wait infinitely.

3. Prevented double-spinning in mujoco_ros2_control
   - Used a future timeout check (`wait_for`) instead of `spin_until_future_complete` so we don't block an already active background executor.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using clang-format.
- [ ] Add a brief explanation of your changes to the [changelog](CHANGELOG.md).
