### PR TITLE
[mujoco_ros] fixed to avoid pedantic error with GCC9

### DIFF
--- a/mujoco_ros/include/mujoco_ros/util.hpp
+++ b/mujoco_ros/include/mujoco_ros/util.hpp
@@ -133,6 +133,6 @@ static inline std::string vector_to_string(const std::vector<T> &vec)
 		}
 	}
 	return oss.str();
-};
+}
 
 } // namespace mujoco_ros::util


### PR DESCRIPTION
### Description
When we build on noetic, following error occuered. 
```
Errors << mujoco_ros:make /home/runner/catkin_ws/logs/mujoco_ros/build.make.000.log
In file included from /home/runner/catkin_ws/src/mujoco_ros_pkgs/mujoco_ros/src/ros_one/ros_api.cpp:45:
/home/runner/catkin_ws/src/mujoco_ros_pkgs/mujoco_ros/include/mujoco_ros/util.hpp:136:2: error: extra ‘;’ [-Werror=pedantic]
  136 | };
      |  ^
In file included from /home/runner/catkin_ws/src/mujoco_ros_pkgs/mujoco_ros/src/physics.cpp:45:
/home/runner/catkin_ws/src/mujoco_ros_pkgs/mujoco_ros/include/mujoco_ros/util.hpp:136:2: error: extra ‘;’ [-Werror=pedantic]
  136 | };
      |  ^
cc1plus: all warnings being treated as errors
make[2]: *** [src/CMakeFiles/mujoco_ros.dir/build.make:128: src/CMakeFiles/mujoco_ros.dir/physics.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
cc1plus: all warnings being treated as errors
Install Space Layout:        None
make[2]: *** [src/CMakeFiles/mujoco_ros.dir/build.make:89: src/CMakeFiles/mujoco_ros.dir/ros_one/ros_api.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1978: src/CMakeFiles/mujoco_ros.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
cd /home/runner/catkin_ws/build/mujoco_ros; catkin build --get-env mujoco_ros | catkin env -si  /usr/bin/make --jobserver-auth=3,4; cd -
```
The cause of this problem is unnecessary `;` in `mujoco_ros/include/mujoco_ros/util.hpp`


### Checklist
- [x] **Required by CI**: Code is auto formatted using clang-format.
- [ ] Add a brief explanation of your changes to the [changelog](CHANGELOG.md).
